### PR TITLE
Updated for GH2 + more

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,13 +75,13 @@ jobs:
         shell: bash
         run: |
           "$GITHUB_WORKSPACE/${{ matrix.yak_bin }}" build --platform ${{ matrix.yak_platform }}
-        working-directory: rhino/plugin/bin/Release
+        working-directory: rhino/plugin/bin/${{ matrix.rhino_target }}/Release
 
       - name: Upload yak artifact
         if: matrix.configuration == 'Release'
         uses: actions/upload-artifact@v5
         with:
           name: rhino-mcp-platform-${{ matrix.rhino_target }}-${{ matrix.yak_platform }}
-          path: rhino/plugin/bin/Release/*.yak
+          path: rhino/plugin/bin/${{ matrix.rhino_target }}/Release/*.yak
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest]
-        configuration: [Debug, Release]
         rhino_target: [R8, R9]
         include:
           # router_rids uses %3B to escape ; — MSBuild's -p: switch otherwise
@@ -53,32 +52,29 @@ jobs:
 
       - name: Build router (framework-dependent, for tests)
         if: matrix.rhino_target == 'R9'
-        run: dotnet build rhino/router/Router.csproj --configuration ${{ matrix.configuration }} --no-restore
+        run: dotnet build rhino/router/Router.csproj --configuration Release --no-restore
 
       - name: Test router
         if: matrix.rhino_target == 'R9'
-        run: dotnet test tests/router/Router.Tests.csproj --configuration ${{ matrix.configuration }} --verbosity normal
+        run: dotnet test tests/router/Router.Tests.csproj --configuration Release --verbosity normal
 
       - name: Build plugin (publishes router self-contained for RIDs ${{ matrix.router_rids }} into yak output)
         shell: bash
-        run: dotnet build rhino/plugin/RhMcp.csproj --configuration ${{ matrix.configuration }} '-p:RouterRids=${{ matrix.router_rids }}' '-p:RhinoTarget=${{ matrix.rhino_target }}'
+        run: dotnet build rhino/plugin/RhMcp.csproj --configuration Release '-p:RouterRids=${{ matrix.router_rids }}' '-p:RhinoTarget=${{ matrix.rhino_target }}'
 
       - name: Download yak CLI
-        if: matrix.configuration == 'Release'
         shell: bash
         run: |
           curl -fsSL -o "${{ matrix.yak_bin }}" "${{ matrix.yak_url }}"
           chmod +x "${{ matrix.yak_bin }}"
 
       - name: Build yak package (${{ matrix.yak_platform }} / ${{ matrix.rhino_target }})
-        if: matrix.configuration == 'Release'
         shell: bash
         run: |
           "$GITHUB_WORKSPACE/${{ matrix.yak_bin }}" build --platform ${{ matrix.yak_platform }}
         working-directory: rhino/plugin/bin/${{ matrix.rhino_target }}/Release
 
       - name: Upload yak artifact
-        if: matrix.configuration == 'Release'
         uses: actions/upload-artifact@v5
         with:
           name: rhino-mcp-platform-${{ matrix.rhino_target }}-${{ matrix.yak_platform }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
         configuration: [Debug, Release]
+        rhino_target: [R8, R9]
         include:
           # router_rids uses %3B to escape ; — MSBuild's -p: switch otherwise
           # splits the value on ; and treats the second half as a new property.
@@ -24,14 +25,13 @@ jobs:
           - os: windows-latest
             router_rids: win-x64%3Bwin-arm64
             yak_platform: win
-            # Windows runs yak.exe natively; bash run-command is empty.
-            yak_run: ""
+            yak_url: https://files.mcneel.com/yak/tools/0.13.0/yak.exe
+            yak_bin: yak.exe
           - os: macos-latest
             router_rids: osx-arm64
             yak_platform: mac
-            # McNeel only publishes yak.exe (a .NET Framework exe). On Mac we run it
-            # under Mono, which is preinstalled on macos-latest GitHub runners.
-            yak_run: "mono"
+            yak_url: https://files.mcneel.com/yak/tools/0.13.0/mac/yak
+            yak_bin: yak
 
     runs-on: ${{ matrix.os }}
 
@@ -44,48 +44,44 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: Restore router (framework-dependent, for tests)
+        # Router is target-agnostic; only restore/test it once per OS+config.
+        if: matrix.rhino_target == 'R9'
         run: dotnet restore rhino/router/Router.csproj
 
       - name: Restore plugin
-        run: dotnet restore rhino/plugin/RhMcp.csproj
+        run: dotnet restore rhino/plugin/RhMcp.csproj '-p:RhinoTarget=${{ matrix.rhino_target }}'
 
       - name: Build router (framework-dependent, for tests)
+        if: matrix.rhino_target == 'R9'
         run: dotnet build rhino/router/Router.csproj --configuration ${{ matrix.configuration }} --no-restore
 
       - name: Test router
+        if: matrix.rhino_target == 'R9'
         run: dotnet test tests/router/Router.Tests.csproj --configuration ${{ matrix.configuration }} --verbosity normal
 
       - name: Build plugin (publishes router self-contained for RIDs ${{ matrix.router_rids }} into yak output)
         shell: bash
-        run: dotnet build rhino/plugin/RhMcp.csproj --configuration ${{ matrix.configuration }} '-p:RouterRids=${{ matrix.router_rids }}'
-
-      - name: Ensure Mono is installed (mac only)
-        if: matrix.configuration == 'Release' && matrix.yak_platform == 'mac'
-        shell: bash
-        run: |
-          if ! command -v mono >/dev/null 2>&1; then
-            brew install mono
-          fi
-          mono --version | head -1
+        run: dotnet build rhino/plugin/RhMcp.csproj --configuration ${{ matrix.configuration }} '-p:RouterRids=${{ matrix.router_rids }}' '-p:RhinoTarget=${{ matrix.rhino_target }}'
 
       - name: Download yak CLI
         if: matrix.configuration == 'Release'
         shell: bash
         run: |
-          curl -fsSL -o yak.exe https://files.mcneel.com/yak/tools/latest/yak.exe
-          chmod +x yak.exe
+          curl -fsSL -o "${{ matrix.yak_bin }}" "${{ matrix.yak_url }}"
+          chmod +x "${{ matrix.yak_bin }}"
 
-      - name: Build yak package (${{ matrix.yak_platform }})
+      - name: Build yak package (${{ matrix.yak_platform }} / ${{ matrix.rhino_target }})
         if: matrix.configuration == 'Release'
         shell: bash
-        run: ${{ matrix.yak_run }} "$GITHUB_WORKSPACE/yak.exe" build --platform ${{ matrix.yak_platform }}
+        run: |
+          "$GITHUB_WORKSPACE/${{ matrix.yak_bin }}" build --platform ${{ matrix.yak_platform }}
         working-directory: rhino/plugin/bin/Release
 
       - name: Upload yak artifact
         if: matrix.configuration == 'Release'
         uses: actions/upload-artifact@v5
         with:
-          name: rhino-mcp-platform-${{ matrix.yak_platform }}
+          name: rhino-mcp-platform-${{ matrix.rhino_target }}-${{ matrix.yak_platform }}
           path: rhino/plugin/bin/Release/*.yak
           if-no-files-found: error
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 # Mono auto generated files
 mono_crash.*
 
+# C# Auto-Gen
+*.g.cs
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.0",
+  "version": "0.1.0",
   "configurations": [
     {
       "name": "Rhino 9 - netcore",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "name": "Rhino 9 - netcore",
       "type": "coreclr",
       "request": "launch",
-      "preLaunchTask": "build",
+      "preLaunchTask": "build (R9)",
       "program": "",
       "osx": {
         "program": "/Applications/RhinoWIP.app/Contents/MacOS/Rhinoceros",
@@ -20,7 +20,7 @@
         ]
       },
       "env": {
-        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/rhino/plugin/bin/Debug"
+        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/rhino/plugin/bin/R9/Debug"
       },
       "cwd": "${workspaceFolder}",
       "stopAtEntry": false,
@@ -36,25 +36,6 @@
       "cwd": "${workspaceFolder}/rhino/router",
       "stopAtEntry": false,
       "console": "integratedTerminal"
-    },
-    {
-      "name": "Rhino 9 Windows - netfx",
-      "type": "clr",
-      "request": "launch",
-      "preLaunchTask": "build",
-      "windows": {
-        "program": "C:\\Program Files\\Rhino 9 WIP\\System\\Rhino.exe",
-        "targetArchitecture": "x86_64",
-        "args": [
-          "/netfx"
-        ]
-      },
-      "env": {
-        "RHINO_PACKAGE_DIRS": "${workspaceFolder}/rhino/plugin/bin/Debug"
-      },
-      "cwd": "${workspaceFolder}",
-      "stopAtEntry": false,
-      "console": "internalConsole"
     },
   ],
   "compounds": []

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,14 +9,14 @@
       "program": "",
       "osx": {
         "program": "/Applications/RhinoWIP.app/Contents/MacOS/Rhinoceros",
-        "args": ["-runscript=_-RhinoMCP _Enter"],
+        "args": ["-runscript=_StartMCP"],
       },
       "windows": {
         "program": "C:\\Program Files\\Rhino 9 WIP\\System\\Rhino.exe",
         "targetArchitecture": "x86_64",
         "args": [
           "/netcore",
-          "/runscript=_-RhinoMCP _Enter"
+          "/runscript=_StartMCP _Enter"
         ]
       },
       "env": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -123,12 +123,12 @@
       "label": "install yak (Rhino 8)",
       "type": "shell",
       "dependsOn": "pack yak (R8)",
-      "args": ["install", "*.yak"],
       "windows": {
-        "command": "C:/Program Files/Rhino 8/System/Yak.exe"
+        "command": "Get-ChildItem *.yak | ForEach-Object { & 'C:/Program Files/Rhino 8/System/Yak.exe' install $_.Name }"
       },
       "osx": {
-        "command": "/Applications/Rhino 8.app/Contents/Resources/bin/yak"
+        "command": "/Applications/Rhino 8.app/Contents/Resources/bin/yak",
+        "args": ["install", "*.yak"]
       },
       "linux": {
         "command": "echo",
@@ -148,12 +148,12 @@
       "label": "install yak (WIP)",
       "type": "shell",
       "dependsOn": "pack yak (R9)",
-      "args": ["install", "*.yak"],
       "windows": {
-        "command": "C:/Program Files/Rhino 9 WIP/System/Yak.exe"
+        "command": "Get-ChildItem *.yak | ForEach-Object { & 'C:/Program Files/Rhino 9 WIP/System/Yak.exe' install $_.Name }"
       },
       "osx": {
-        "command": "/Applications/RhinoWIP.app/Contents/Resources/bin/yak"
+        "command": "/Applications/RhinoWIP.app/Contents/Resources/bin/yak",
+        "args": ["install", "*.yak"]
       },
       "linux": {
         "command": "echo",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,12 +34,13 @@
       "group": "build"
     },
     {
-      "label": "build release",
+      "label": "build release (R8)",
       "command": "dotnet",
       "type": "shell",
       "args": [
         "build",
         "-c:Release",
+        "-p:RhinoTarget=R8",
         "-clp:NoSummary",
         "${workspaceFolder}/rhino/plugin/RhMcp.csproj"
       ],
@@ -51,9 +52,27 @@
       "group": "build"
     },
     {
-      "label": "pack yak",
+      "label": "build release (R9)",
+      "command": "dotnet",
       "type": "shell",
-      "dependsOn": "build release",
+      "args": [
+        "build",
+        "-c:Release",
+        "-p:RhinoTarget=R9",
+        "-clp:NoSummary",
+        "${workspaceFolder}/rhino/plugin/RhMcp.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "pack yak (R8)",
+      "type": "shell",
+      "dependsOn": "build release (R8)",
       "args": ["build"],
       "windows": {
         "command": "C:/Program Files/Rhino 8/System/Yak.exe"
@@ -66,7 +85,57 @@
         "args": ["Yak build on Linux is unsupported."]
       },
       "options": {
-        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release"
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/R8/Release"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "pack yak (R9)",
+      "type": "shell",
+      "dependsOn": "build release (R9)",
+      "args": ["build"],
+      "windows": {
+        "command": "C:/Program Files/Rhino 8/System/Yak.exe"
+      },
+      "osx": {
+        "command": "/Applications/Rhino 8.app/Contents/Resources/bin/yak"
+      },
+      "linux": {
+        "command": "echo",
+        "args": ["Yak build on Linux is unsupported."]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/R9/Release"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "install yak (Rhino 8)",
+      "type": "shell",
+      "dependsOn": "pack yak (R8)",
+      "args": ["install", "*.yak"],
+      "windows": {
+        "command": "C:/Program Files/Rhino 8/System/Yak.exe"
+      },
+      "osx": {
+        "command": "/Applications/Rhino 8.app/Contents/Resources/bin/yak"
+      },
+      "linux": {
+        "command": "echo",
+        "args": ["Yak install on Linux is unsupported."]
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/R8/Release"
       },
       "problemMatcher": [],
       "presentation": {
@@ -78,7 +147,7 @@
     {
       "label": "install yak (WIP)",
       "type": "shell",
-      "dependsOn": "pack yak",
+      "dependsOn": "pack yak (R9)",
       "args": ["install", "*.yak"],
       "windows": {
         "command": "C:/Program Files/Rhino 9 WIP/System/Yak.exe"
@@ -91,7 +160,35 @@
         "args": ["Yak install on Linux is unsupported."]
       },
       "options": {
-        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release"
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/R9/Release"
+      },
+      "problemMatcher": [],
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "install yak (Rhino 8 + WIP)",
+      "dependsOn": ["install yak (Rhino 8)", "install yak (WIP)"],
+      "dependsOrder": "sequence",
+      "problemMatcher": [],
+      "group": "build"
+    },
+    {
+      "label": "uninstall yak (Rhino 8)",
+      "type": "shell",
+      "args": ["uninstall", "Rhino-MCP-Platform"],
+      "windows": {
+        "command": "C:/Program Files/Rhino 8/System/Yak.exe"
+      },
+      "osx": {
+        "command": "/Applications/Rhino 8.app/Contents/Resources/bin/yak"
+      },
+      "linux": {
+        "command": "echo",
+        "args": ["Yak uninstall on Linux is unsupported."]
       },
       "problemMatcher": [],
       "presentation": {
@@ -119,6 +216,12 @@
         "reveal": "always",
         "clear": true
       },
+      "group": "build"
+    },
+    {
+      "label": "uninstall yak (Rhino 8 + WIP)",
+      "dependsOn": ["uninstall yak (Rhino 8)", "uninstall yak (WIP)"],
+      "problemMatcher": [],
       "group": "build"
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,11 +2,29 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "build",
+      "label": "build (R8)",
       "command": "dotnet",
       "type": "shell",
       "args": [
         "build",
+        "-p:RhinoTarget=R8",
+        "-clp:NoSummary",
+        "${workspaceFolder}/rhino/plugin/RhMcp.csproj"
+      ],
+      "problemMatcher": "$msCompile",
+      "presentation": {
+        "reveal": "always",
+        "clear": true
+      },
+      "group": "build"
+    },
+    {
+      "label": "build (R9)",
+      "command": "dotnet",
+      "type": "shell",
+      "args": [
+        "build",
+        "-p:RhinoTarget=R9",
         "-clp:NoSummary",
         "${workspaceFolder}/rhino/plugin/RhMcp.csproj"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,7 +66,7 @@
         "args": ["Yak build on Linux is unsupported."]
       },
       "options": {
-        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release/net8.0"
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release"
       },
       "problemMatcher": [],
       "presentation": {
@@ -91,7 +91,7 @@
         "args": ["Yak install on Linux is unsupported."]
       },
       "options": {
-        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release/net8.0"
+        "cwd": "${workspaceFolder}/rhino/plugin/bin/Release"
       },
       "problemMatcher": [],
       "presentation": {

--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ Ask questions, post discussions and ideas to the [Rhino Discourse forums](https:
 # What can an MCP Server do?
 
 MCP Servers are a new way of controlling your programs. They let you control Rhino but using written human language. You can ask about the model, have your AI agent create things in the model, or organise it for you. The capabilities are endless.
+
+## What can the RhinoMCP Server do?
+
+### Rhino
+- Model 3d geometry given an image
+
+### Grasshopper 1/2
+- Create scripts
+- Upgrade GH1 scripts to 2
+- De-spaghettify scripts
+- Simplify scripts
+
+### Both
+- Create C#/py scripts for you

--- a/connector/manifest.json
+++ b/connector/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.2",
   "name": "rhino-mcp-platform",
   "display_name": "Rhino MCP Platform",
-  "version": "0.2.0",
+  "version": "0.1.0",
   "description": "Desktop Connector for Rhino3d and Grasshopper",
   "long_description": "Bridges Claude to Rhino3d and Grasshopper. Requires the Rhino-MCP-Platform Rhino plugin to be installed via Rhino's PackageManager.",
   "author": {

--- a/rhino/plugin/BackgroundThreadAttribute.cs
+++ b/rhino/plugin/BackgroundThreadAttribute.cs
@@ -1,0 +1,9 @@
+namespace RhMcp;
+
+// Marker for MCP tools that must NOT be marshalled to the Rhino UI thread.
+// Default behaviour (no attribute) is main-thread dispatch via MainThreadFilter,
+// because most tools touch Rhino/Grasshopper state and macOS aborts if AppKit
+// is touched off the main thread. Apply this only to tools that are pure data
+// or long-running CPU work where blocking the UI thread is undesirable.
+[AttributeUsage(AttributeTargets.Method)]
+internal sealed class BackgroundThreadAttribute : Attribute { }

--- a/rhino/plugin/ConnectCommand.cs
+++ b/rhino/plugin/ConnectCommand.cs
@@ -86,9 +86,10 @@ Then tell the user to reload";
     private static string RouterPath()
     {
         string pluginDir = Path.GetDirectoryName(typeof(RhMcpPlugin).Assembly.Location) ?? string.Empty;
+        string routerRoot = Path.GetFullPath(Path.Combine(pluginDir, "..", "router"));
         string rid = GetRid();
         string exe = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "rhino-mcp-router.exe" : "rhino-mcp-router";
-        return Path.Combine(pluginDir, "router", rid, exe);
+        return Path.Combine(routerRoot, rid, exe);
     }
 
     private static string GetRid()

--- a/rhino/plugin/Internal/RouterControlTool.cs
+++ b/rhino/plugin/Internal/RouterControlTool.cs
@@ -65,7 +65,7 @@ public static class RouterControlTool
     }
 
     [McpServerTool(Name = "_router_close_listener")]
-    [Description("Router-internal: stop the MCP listener on the given port. The doc is left open — the user can close it manually.")]
+    [Description("Router-internal: stop the MCP listener on the given port and close its associated doc without saving.")]
     public static string CloseListener(int port)
     {
         bool ok = false;

--- a/rhino/plugin/Internal/RouterControlTool.cs
+++ b/rhino/plugin/Internal/RouterControlTool.cs
@@ -4,12 +4,6 @@ namespace RhMcp.Internal;
 // HTTP endpoint as a control channel; they are intentionally kept out of
 // /plugin/Tools/ so the router's source generator (which scans that folder)
 // cannot turn them into agent-facing proxies.
-//
-// Used on macOS, where Rhino is single-process-per-bundle-id: multiple "slots"
-// for the same Rhino version share one OS process, and each slot is a separate
-// RhinoDoc with its own MCP listener. The first slot is launched via `open -a`
-// with `_-RhinoMCP <port> _Enter`; subsequent slots are created by calling
-// SpawnListener on the existing first listener.
 [McpServerToolType]
 public static class RouterControlTool
 {

--- a/rhino/plugin/MCPCommand.cs
+++ b/rhino/plugin/MCPCommand.cs
@@ -23,27 +23,6 @@ public class MCPCommand : Command
         if (go.Get() != GetResult.Number) return Result.Cancel;
         port = go.Number();
 
-        if (RhinoMcpHost.HasStarted(doc))
-        {
-            if (!RhinoMcpHost.RestartOnPort(doc, port))
-            {
-                RhinoApp.WriteLine($"[Rhino MCP] Failed to bind port {port}.");
-                return Result.Failure;
-            }
-            else
-            {
-                RhinoApp.WriteLine($"[Rhino MCP] Restarted on http://localhost:{port}/");
-            }
-        }
-        else if (RhinoMcpHost.Start(doc, port))
-        {
-            // Start runs WriteLine
-        }
-        else
-        {
-            RhinoApp.WriteLine($"[Rhino MCP] MCP server failed to start. Try a different port.");
-        }
-
-        return Result.Success;
+        return RhinoMcpHost.StartOrRestart(doc, port) ? Result.Success : Result.Failure;
     }
 }

--- a/rhino/plugin/MainThreadFilter.cs
+++ b/rhino/plugin/MainThreadFilter.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using System.Threading.Tasks;
+
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace RhMcp;
+
+// Every MCP tool call is dispatched onto the Rhino UI thread by default so
+// tool bodies can freely touch Rhino/Grasshopper without crashing macOS's
+// AppKit thread check. Tools that explicitly opt out via [BackgroundThread]
+// run on whatever worker thread the MCP host gave us.
+//
+// The marshal is "proper": we post via InvokeOnUiThread (non-blocking) and
+// resume on a TCS, instead of blocking a worker on .GetResult() — which
+// would deadlock the moment a tool body genuinely awaits.
+internal static class MainThreadFilter
+{
+    public static McpRequestFilter<CallToolRequestParams, CallToolResult> Create(IReadOnlySet<string> optOut) =>
+        next => async (request, ct) =>
+        {
+            var name = request.Params?.Name;
+            if (name is not null && optOut.Contains(name))
+                return await next(request, ct);
+
+            var tcs = new TaskCompletionSource<CallToolResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+            RhinoApp.InvokeOnUiThread(new Action(async () =>
+            {
+                try { tcs.SetResult(await next(request, ct)); }
+                catch (Exception ex) { tcs.SetException(ex); }
+            }), null);
+            return await tcs.Task;
+        };
+
+    public static HashSet<string> ScanOptOut(Assembly asm)
+    {
+        var set = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in asm.GetTypes())
+        {
+            if (t.GetCustomAttribute<McpServerToolTypeAttribute>() is null) continue;
+            const BindingFlags flags = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly;
+            foreach (var m in t.GetMethods(flags))
+            {
+                var tool = m.GetCustomAttribute<McpServerToolAttribute>();
+                if (tool is null) continue;
+                if (m.GetCustomAttribute<BackgroundThreadAttribute>() is null) continue;
+                set.Add(tool.Name ?? m.Name);
+            }
+        }
+        return set;
+    }
+}

--- a/rhino/plugin/McpServer.cs
+++ b/rhino/plugin/McpServer.cs
@@ -28,7 +28,11 @@ internal sealed class McpServer : IDisposable
             var builder = WebApplication.CreateSlimBuilder();
             builder.Logging.ClearProviders();
             builder.Logging.AddProvider(new RhinoLoggerProvider());
+#if DEBUG
             builder.Logging.SetMinimumLevel(LogLevel.Information);
+#else
+            builder.Logging.SetMinimumLevel(LogLevel.Warning);
+#endif
             builder.Services.Configure<KestrelServerOptions>(o => o.ListenLocalhost(port));
 
             builder.Services.AddSingleton(doc);

--- a/rhino/plugin/McpServer.cs
+++ b/rhino/plugin/McpServer.cs
@@ -37,15 +37,20 @@ internal sealed class McpServer : IDisposable
 
             builder.Services.AddSingleton(doc);
 
+            var asm = typeof(McpServer).Assembly;
+            var optOut = MainThreadFilter.ScanOptOut(asm);
+
             var mcp = builder.Services
                 .AddMcpServer(o =>
                 {
                     o.ServerInfo = new() { Name = "rhino-mcp", Version = "0.1.0" };
                 })
                 .WithHttpTransport(o => o.Stateless = true)
-                .WithToolsFromAssembly(typeof(McpServer).Assembly)
-                .WithResourcesFromAssembly(typeof(McpServer).Assembly)
-                .WithPromptsFromAssembly(typeof(McpServer).Assembly);
+                .WithToolsFromAssembly(asm)
+                .WithResourcesFromAssembly(asm)
+                .WithPromptsFromAssembly(asm);
+
+            mcp.WithRequestFilters(f => f.AddCallToolFilter(MainThreadFilter.Create(optOut)));
 
 #if DEBUG
             mcp.WithRequestFilters(f => f.AddCallToolFilter(DebugErrorFilter.Filter));

--- a/rhino/plugin/Properties/launchSettings.json
+++ b/rhino/plugin/Properties/launchSettings.json
@@ -8,13 +8,5 @@
         "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
       }
     },
-    "Rhino 8 - netfx": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
-      "commandLineArgs": "/netfx",
-      "environmentVariables": {
-        "RHINO_PACKAGE_DIRS": "$(ProjectDir)$(OutputPath)\\"
-      }
-    },
   }
 }

--- a/rhino/plugin/Resources/GH1/GH1_Utils.cs
+++ b/rhino/plugin/Resources/GH1/GH1_Utils.cs
@@ -12,16 +12,13 @@ public static class GH1_Utils
     doc = default!;
     if (Instances.ActiveCanvas is null)
     {
-      RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_Grasshopper", true));
+      RhinoApp.RunScript("_Grasshopper", true);
       if (Instances.ActiveCanvas is null) return false;
     }
 
     var canvas = Instances.ActiveCanvas;
 
-    RhinoApp.InvokeAndWait(() =>
-    {
-      canvas.Document ??= new GH_Document();
-    });
+    canvas.Document ??= new GH_Document();
     doc = canvas.Document;
     return doc is not null;
   }

--- a/rhino/plugin/Resources/GH1/GH1_Utils.cs
+++ b/rhino/plugin/Resources/GH1/GH1_Utils.cs
@@ -7,12 +7,12 @@ namespace RhMcp.Resources;
 public static class GH1_Utils
 {
 
-  public static bool TryGetOrCreateDoc(out GH_Document doc)
+  public static bool TryGetOrCreateDoc(RhinoDoc rhDoc, out GH_Document doc)
   {
     doc = default!;
     if (Instances.ActiveCanvas is null)
     {
-      RhinoApp.RunScript(doc.RuntimeSerialNumber, "_Grasshopper", true);
+      RhinoApp.RunScript(rhDoc.RuntimeSerialNumber, "_Grasshopper", true);
       if (Instances.ActiveCanvas is null) return false;
     }
 

--- a/rhino/plugin/Resources/GH1/GH1_Utils.cs
+++ b/rhino/plugin/Resources/GH1/GH1_Utils.cs
@@ -12,7 +12,7 @@ public static class GH1_Utils
     doc = default!;
     if (Instances.ActiveCanvas is null)
     {
-      RhinoApp.RunScript("_Grasshopper", true);
+      RhinoApp.RunScript(doc.RuntimeSerialNumber, "_Grasshopper", true);
       if (Instances.ActiveCanvas is null) return false;
     }
 

--- a/rhino/plugin/Resources/GH2/GH2_GraphOps.cs
+++ b/rhino/plugin/Resources/GH2/GH2_GraphOps.cs
@@ -1,0 +1,75 @@
+using Grasshopper2.Components;
+using Grasshopper2.Doc;
+using Grasshopper2.Parameters;
+
+namespace RhMcp.Resources;
+
+public static class GH2_GraphOps
+{
+    public static bool TryResolveOutput(IDocumentObject obj, string selector, out IParameter? param, out string error)
+    {
+        param = null;
+        error = "";
+        if (obj is Component comp)
+            return TryPickParam(comp.Parameters.Outputs.ToList(), selector, "output", out param, out error);
+        if (obj is IParameter p)
+        {
+            if (selector is null || selector.Length == 0 || selector == "0") { param = p; return true; }
+            error = $"Object '{obj.InstanceId}' is a Param; expected '' or '0' for src, got '{selector}'";
+            return false;
+        }
+        error = $"Object '{obj.InstanceId}' has no outputs";
+        return false;
+    }
+
+    public static bool TryResolveInput(IDocumentObject obj, string selector, out IParameter? param, out string error)
+    {
+        param = null;
+        error = "";
+        if (obj is Component comp)
+            return TryPickParam(comp.Parameters.Inputs.ToList(), selector, "input", out param, out error);
+        if (obj is IParameter p)
+        {
+            if (GH2_Utils.IsValueSource(p))
+            {
+                error = $"destination '{p.DisplayName}' is a value source, not an input";
+                return false;
+            }
+            if (selector is null || selector.Length == 0 || selector == "0") { param = p; return true; }
+            error = $"Object '{obj.InstanceId}' is a Param; expected '' or '0' for dst, got '{selector}'";
+            return false;
+        }
+        error = $"Object '{obj.InstanceId}' has no inputs";
+        return false;
+    }
+
+    private static bool TryPickParam(IList<IParameter> list, string selector, string kind, out IParameter? param, out string error)
+    {
+        param = null;
+        error = "";
+
+        if (selector is null || selector.Length == 0)
+        {
+            if (list.Count == 0) { error = $"Component has no {kind} params"; return false; }
+            param = list[0];
+            return true;
+        }
+
+        if (int.TryParse(selector, out int idx))
+        {
+            if (idx < 0 || idx >= list.Count) { error = $"{kind} index {idx} out of range (count {list.Count})"; return false; }
+            param = list[idx];
+            return true;
+        }
+
+        foreach (var p in list)
+            if (string.Equals(p.Nomen.Name, selector, StringComparison.OrdinalIgnoreCase)) { param = p; return true; }
+        foreach (var p in list)
+            if (string.Equals(p.UserName, selector, StringComparison.OrdinalIgnoreCase)) { param = p; return true; }
+        foreach (var p in list)
+            if (string.Equals(p.DisplayName, selector, StringComparison.OrdinalIgnoreCase)) { param = p; return true; }
+
+        error = $"No {kind} named '{selector}'";
+        return false;
+    }
+}

--- a/rhino/plugin/Resources/GH2/GH2_GraphOps.cs
+++ b/rhino/plugin/Resources/GH2/GH2_GraphOps.cs
@@ -1,6 +1,7 @@
-using Grasshopper2.Components;
 using Grasshopper2.Doc;
 using Grasshopper2.Parameters;
+
+using GH2Component = Grasshopper2.Components.Component;
 
 namespace RhMcp.Resources;
 
@@ -10,7 +11,7 @@ public static class GH2_GraphOps
     {
         param = null;
         error = "";
-        if (obj is Component comp)
+        if (obj is GH2Component comp)
             return TryPickParam(comp.Parameters.Outputs.ToList(), selector, "output", out param, out error);
         if (obj is IParameter p)
         {
@@ -26,7 +27,7 @@ public static class GH2_GraphOps
     {
         param = null;
         error = "";
-        if (obj is Component comp)
+        if (obj is GH2Component comp)
             return TryPickParam(comp.Parameters.Inputs.ToList(), selector, "input", out param, out error);
         if (obj is IParameter p)
         {

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -1,12 +1,18 @@
 using Grasshopper2;
+using Grasshopper2.Components;
+using Grasshopper2.Doc;
+using Grasshopper2.Framework;
+using Grasshopper2.Parameters;
+using Grasshopper2.Parameters.Special;
 using Grasshopper2.UI;
+using Grasshopper2.UI.Canvas;
 
 namespace RhMcp.Resources;
 
 public static class GH2_Utils
 {
 
-  public static bool TryGetDoc(out Grasshopper2.Doc.Document doc)
+  public static bool TryGetDoc(out Document doc)
   {
     doc = default!;
 
@@ -14,6 +20,7 @@ public static class GH2_Utils
     if (editor is null)
     {
       RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_G2", true));
+      editor = Editor.Instance;
       if (editor is null) return false;
     }
 
@@ -25,8 +32,27 @@ public static class GH2_Utils
   public static bool TryLoadDocument(string path)
   {
     if (!TryGetDoc(out _)) return false;
-    return Editor.Instance.Canvas.TryOpenDocument(path, Grasshopper2.UI.Canvas.OpenDocumentOptions.Default);
+    return Editor.Instance.Documents.TryOpenDocument(path, OpenDocumentOptions.Default);
   }
+
+  public static void Redraw()
+  {
+    var canvas = Editor.Instance?.Canvas;
+    if (canvas is null) return;
+    canvas.Invalidate();
+  }
+
+  public static string ClassifyKind(Type t)
+  {
+    if (t is null) return "Other";
+    if (typeof(NumberSliderObject).IsAssignableFrom(t)) return "Slider";
+    if (typeof(Component).IsAssignableFrom(t)) return "Component";
+    if (typeof(IParameter).IsAssignableFrom(t)) return "Param";
+    return "Other";
+  }
+
+  public static bool IsValueSource(IDocumentObject obj) =>
+    obj.GetType().Namespace?.Contains("Parameters.Special") ?? false;
 
   private static Guid GH2_PlugInId { get; } = new Guid("8307876d-a461-4daa-bb77-eb3715925513");
   public static bool IsInstalled()

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -20,7 +20,7 @@ public static class GH2_Utils
     Editor editor = Editor.Instance;
     if (editor is null)
     {
-      RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_G2", true));
+      RhinoApp.RunScript("_G2", true);
       editor = Editor.Instance;
       if (editor is null) return false;
     }

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -13,14 +13,14 @@ namespace RhMcp.Resources;
 public static class GH2_Utils
 {
 
-  public static bool TryGetDoc(out Document doc)
+  public static bool TryGetDoc(RhinoDoc rhDoc, out Document doc)
   {
     doc = default!;
 
     Editor editor = Editor.Instance;
     if (editor is null)
     {
-      RhinoApp.RunScript(doc.RuntimeSerialNumber, "_G2", true);
+      RhinoApp.RunScript(rhDoc.RuntimeSerialNumber, "_G2", true);
       editor = Editor.Instance;
       if (editor is null) return false;
     }
@@ -30,9 +30,9 @@ public static class GH2_Utils
     return doc is not null;
   }
 
-  public static bool TryLoadDocument(string path)
+  public static bool TryLoadDocument(RhinoDoc rhDoc, string path)
   {
-    if (!TryGetDoc(out _)) return false;
+    if (!TryGetDoc(rhDoc, out _)) return false;
     return Editor.Instance.Documents.TryOpenDocument(path, OpenDocumentOptions.Default);
   }
 

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -20,7 +20,7 @@ public static class GH2_Utils
     Editor editor = Editor.Instance;
     if (editor is null)
     {
-      RhinoApp.RunScript("_G2", true);
+      RhinoApp.RunScript(doc.RuntimeSerialNumber, "_G2", true);
       editor = Editor.Instance;
       if (editor is null) return false;
     }

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -1,11 +1,12 @@
 using Grasshopper2;
-using Grasshopper2.Components;
 using Grasshopper2.Doc;
 using Grasshopper2.Framework;
 using Grasshopper2.Parameters;
 using Grasshopper2.Parameters.Special;
 using Grasshopper2.UI;
 using Grasshopper2.UI.Canvas;
+
+using GH2Component = Grasshopper2.Components.Component;
 
 namespace RhMcp.Resources;
 
@@ -46,7 +47,7 @@ public static class GH2_Utils
   {
     if (t is null) return "Other";
     if (typeof(NumberSliderObject).IsAssignableFrom(t)) return "Slider";
-    if (typeof(Component).IsAssignableFrom(t)) return "Component";
+    if (typeof(GH2Component).IsAssignableFrom(t)) return "Component";
     if (typeof(IParameter).IsAssignableFrom(t)) return "Param";
     return "Other";
   }

--- a/rhino/plugin/Resources/GH2/GH2_Utils.cs
+++ b/rhino/plugin/Resources/GH2/GH2_Utils.cs
@@ -55,11 +55,4 @@ public static class GH2_Utils
   public static bool IsValueSource(IDocumentObject obj) =>
     obj.GetType().Namespace?.Contains("Parameters.Special") ?? false;
 
-  private static Guid GH2_PlugInId { get; } = new Guid("8307876d-a461-4daa-bb77-eb3715925513");
-  public static bool IsInstalled()
-  {
-    var plugIn = Rhino.PlugIns.PlugIn.Find(GH2_PlugInId);
-    return plugIn is not null;
-  }
-
 }

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.1.0</Version>
     <Title>Rhino MCP Platform</Title>
     <Company>McNeel</Company>
     <Description>MCP server plugin for Rhino</Description>

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -12,6 +12,15 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <RootNamespace>RhMcp</RootNamespace>
     <AssemblyName>RhinoMcpPlatform</AssemblyName>
+    <!--
+      Segment bin/ by RhinoTarget so R8 and R9 builds coexist. Without this,
+      flipping RhinoTarget clobbers the previous yak staging dir and Rhino 8
+      ends up with a Rhino 9 build (or vice versa). obj/ is intentionally
+      shared — segmenting it from a csproj is fiddly with SDK-style projects,
+      and the cost is just a NuGet restore + recompile when flipping targets.
+    -->
+    <BaseOutputPath>$(MSBuildProjectDirectory)/bin/$(RhinoTarget)/</BaseOutputPath>
+    <YakStagingDir>$(MSBuildProjectDirectory)/bin/$(RhinoTarget)/$(Configuration)</YakStagingDir>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -44,15 +53,15 @@
 
   <!--
     Yak for a net8.0 plugin is built from the parent of the TFM folder, so the
-    manifest and icon live in `bin/$(Configuration)/` (sibling to `net8.0/`).
-    We use an explicit path rather than $(OutputPath)../ because TargetFrameworks
+    manifest and icon live in $(YakStagingDir) (sibling to `net8.0/`). We use
+    that explicit path rather than $(OutputPath)../ because TargetFrameworks
     (plural) enables cross-targeting: AfterTargets="Build" can run in the outer
-    context where $(OutputPath) is `bin/$(Configuration)/` (no TFM), which makes
-    `$(OutputPath)../` resolve to `bin/` — one level too high.
+    context where $(OutputPath) is $(YakStagingDir)/ (no TFM), which makes
+    `$(OutputPath)../` resolve to `bin/$(RhinoTarget)/` — one level too high.
   -->
   <Target Name="BuildYakPackage" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildProjectDirectory)/icon.png" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(MSBuildProjectDirectory)/manifest.yml" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/icon.png" DestinationFolder="$(YakStagingDir)/" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/manifest.yml" DestinationFolder="$(YakStagingDir)/" SkipUnchangedFiles="true" />
   </Target>
 
   <!--
@@ -84,15 +93,15 @@
       which NETSDK1083 then rejects. Exec batches per item on %() in Command.
     -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)/../router"
-          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) -p:RhinoTarget=$(RhinoTarget) --output &quot;$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(_RouterRid.Identity)&quot; --nologo" />
+          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) -p:RhinoTarget=$(RhinoTarget) --output &quot;$(YakStagingDir)/router/%(_RouterRid.Identity)&quot; --nologo" />
     <!--
       Strip debug artifacts after publish. The router's Release config sets
       NativeDebugSymbols=false / DebugType=none, but NativeAOT's macOS publish
       still emits a .dsym bundle (the linker strip step ignores those flags).
       Delete is idempotent so non-existent paths are fine on the other RID.
     -->
-    <RemoveDir Directories="@(_RouterRid->'$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(Identity)/rhino-mcp-router.dsym')" />
-    <Delete Files="@(_RouterRid->'$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(Identity)/rhino-mcp-router.pdb')" />
+    <RemoveDir Directories="@(_RouterRid->'$(YakStagingDir)/router/%(Identity)/rhino-mcp-router.dsym')" />
+    <Delete Files="@(_RouterRid->'$(YakStagingDir)/router/%(Identity)/rhino-mcp-router.pdb')" />
     <Message Importance="high" Text="[Rhino MCP] Bundled router RIDs: $(RouterRids)" />
   </Target>
 
@@ -153,10 +162,10 @@
     <!--
       Hardcode the net8.0/ destination instead of using $(OutputPath). Same
       cross-targeting quirk as BuildYakPackage: at outer-build context with
-      TargetFrameworks plural, $(OutputPath) is `bin/$(Configuration)/` (no
-      TFM subdir), which would scatter ~100 framework DLLs at the Release root.
+      TargetFrameworks plural, $(OutputPath) is $(YakStagingDir)/ (no TFM
+      subdir), which would scatter ~100 framework DLLs at the staging root.
     -->
-    <Copy SourceFiles="@(_AspNetCoreFiles)" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/net8.0/" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="@(_AspNetCoreFiles)" DestinationFolder="$(YakStagingDir)/net8.0/" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="[Rhino MCP] Bundled ASP.NET Core from $(_AspNetCorePath) (subset filter applied)" />
   </Target>
 

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -44,12 +44,15 @@
 
   <!--
     Yak for a net8.0 plugin is built from the parent of the TFM folder, so the
-    manifest and icon live one level up from $(OutputPath). The .yak ends up at
-    bin/$(Configuration)/ alongside the net8.0/ content directory.
+    manifest and icon live in `bin/$(Configuration)/` (sibling to `net8.0/`).
+    We use an explicit path rather than $(OutputPath)../ because TargetFrameworks
+    (plural) enables cross-targeting: AfterTargets="Build" can run in the outer
+    context where $(OutputPath) is `bin/$(Configuration)/` (no TFM), which makes
+    `$(OutputPath)../` resolve to `bin/` — one level too high.
   -->
   <Target Name="BuildYakPackage" AfterTargets="Build">
-    <Copy SourceFiles="$(MSBuildProjectDirectory)/icon.png" DestinationFolder="$(OutputPath)../" SkipUnchangedFiles="true" />
-    <Copy SourceFiles="$(MSBuildProjectDirectory)/manifest.yml" DestinationFolder="$(OutputPath)../" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/icon.png" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/manifest.yml" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/" SkipUnchangedFiles="true" />
   </Target>
 
   <!--
@@ -68,9 +71,6 @@
   </PropertyGroup>
 
   <!--
-    Bundle one published router per RID under `router/<rid>/`. The router lives in
-    a subdirectory (not the plugin root) to keep its single-file extraction and
-    deps isolated from the plugin's bundled ASP.NET Core dlls.
   -->
   <Target Name="BundleRouter" AfterTargets="Build">
     <ItemGroup>
@@ -84,18 +84,16 @@
       which NETSDK1083 then rejects. Exec batches per item on %() in Command.
     -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)/../router"
-          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) -p:RhinoTarget=$(RhinoTarget) --output &quot;bin/$(Configuration)/$(RhinoTarget)/net8.0/%(_RouterRid.Identity)/publish&quot; --nologo" />
-    <ItemGroup>
-      <_RouterPublishedFile Include="$(MSBuildProjectDirectory)/../router/bin/$(Configuration)/$(RhinoTarget)/net8.0/%(_RouterRid.Identity)/publish/**/*">
-        <Rid>%(_RouterRid.Identity)</Rid>
-      </_RouterPublishedFile>
-    </ItemGroup>
-    <Copy SourceFiles="@(_RouterPublishedFile)"
-          DestinationFiles="@(_RouterPublishedFile->'$(OutputPath)router/%(Rid)/%(RecursiveDir)%(Filename)%(Extension)')"
-          SkipUnchangedFiles="true"
-          Condition="'@(_RouterPublishedFile)' != ''" />
+          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) -p:RhinoTarget=$(RhinoTarget) --output &quot;$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(_RouterRid.Identity)&quot; --nologo" />
+    <!--
+      Strip debug artifacts after publish. The router's Release config sets
+      NativeDebugSymbols=false / DebugType=none, but NativeAOT's macOS publish
+      still emits a .dsym bundle (the linker strip step ignores those flags).
+      Delete is idempotent so non-existent paths are fine on the other RID.
+    -->
+    <RemoveDir Directories="@(_RouterRid->'$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(Identity)/rhino-mcp-router.dsym')" />
+    <Delete Files="@(_RouterRid->'$(MSBuildProjectDirectory)/bin/$(Configuration)/router/%(Identity)/rhino-mcp-router.pdb')" />
     <Message Importance="high" Text="[Rhino MCP] Bundled router RIDs: $(RouterRids)" />
-    <Warning Text="[Rhino MCP] No router publish output found for RIDs: $(RouterRids)" Condition="'@(_RouterPublishedFile)' == ''" />
   </Target>
 
   <!--
@@ -152,7 +150,13 @@
           $(_AspNetCorePath)/Microsoft.Extensions.Identity*.dll
         " />
     </ItemGroup>
-    <Copy SourceFiles="@(_AspNetCoreFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
+    <!--
+      Hardcode the net8.0/ destination instead of using $(OutputPath). Same
+      cross-targeting quirk as BuildYakPackage: at outer-build context with
+      TargetFrameworks plural, $(OutputPath) is `bin/$(Configuration)/` (no
+      TFM subdir), which would scatter ~100 framework DLLs at the Release root.
+    -->
+    <Copy SourceFiles="@(_AspNetCoreFiles)" DestinationFolder="$(MSBuildProjectDirectory)/bin/$(Configuration)/net8.0/" SkipUnchangedFiles="true" />
     <Message Importance="high" Text="[Rhino MCP] Bundled ASP.NET Core from $(_AspNetCorePath) (subset filter applied)" />
   </Target>
 

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- Rhino 9: net8.0 -->
+    <RhinoTarget Condition="'$(RhinoTarget)' == ''">R9</RhinoTarget>
     <TargetFrameworks>net8.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <EnableDynamicLoading>true</EnableDynamicLoading>
@@ -22,10 +23,23 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Grasshopper" Version="8.29.26063.11001" />
-    <PackageReference Include="Grasshopper2" Version="2.0.9225-wip.14825" />
-    <PackageReference Include="RhinoCommon" Version="8.29.26063.11001" ExcludeAssets="runtime" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RhinoTarget)' == 'R8'">
+    <PackageReference Include="RhinoCommon" Version="8.29.26063.11001" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="8.29.26063.11001" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RhinoTarget)' == 'R9'">
+    <PackageReference Include="RhinoCommon" Version="9.0.26135.9190-dujour" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="9.0.26135.9190-dujour" />
+    <PackageReference Include="Grasshopper2" Version="9.0.26135.9190-dujour" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(RhinoTarget)' == 'R8'">
+    <Compile Remove="Tools/GH2/**/*.cs" />
+    <Compile Remove="Resources/GH2/**/*.cs" />
   </ItemGroup>
 
   <!--
@@ -70,9 +84,9 @@
       which NETSDK1083 then rejects. Exec batches per item on %() in Command.
     -->
     <Exec WorkingDirectory="$(MSBuildProjectDirectory)/../router"
-          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) --output &quot;bin/$(Configuration)/net8.0/%(_RouterRid.Identity)/publish&quot; --nologo" />
+          Command="dotnet publish Router.csproj --configuration $(Configuration) --runtime %(_RouterRid.Identity) -p:RhinoTarget=$(RhinoTarget) --output &quot;bin/$(Configuration)/$(RhinoTarget)/net8.0/%(_RouterRid.Identity)/publish&quot; --nologo" />
     <ItemGroup>
-      <_RouterPublishedFile Include="$(MSBuildProjectDirectory)/../router/bin/$(Configuration)/net8.0/%(_RouterRid.Identity)/publish/**/*">
+      <_RouterPublishedFile Include="$(MSBuildProjectDirectory)/../router/bin/$(Configuration)/$(RhinoTarget)/net8.0/%(_RouterRid.Identity)/publish/**/*">
         <Rid>%(_RouterRid.Identity)</Rid>
       </_RouterPublishedFile>
     </ItemGroup>

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R9'">
-    <PackageReference Include="RhinoCommon" Version="9.0.26135.9190-dujour" ExcludeAssets="runtime" />
-    <PackageReference Include="Grasshopper" Version="9.0.26135.9190-dujour" />
-    <PackageReference Include="Grasshopper2" Version="9.0.26135.9190-dujour" />
+    <PackageReference Include="RhinoCommon" Version="9.0.26132.12305-wip" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="9.0.26132.12305-wip" />
+    <PackageReference Include="Grasshopper2" Version="9.0.26132.12305-wip" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R8'">

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -41,9 +41,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R9'">
-    <PackageReference Include="RhinoCommon" Version="9.0.26135.9190-dujour" ExcludeAssets="runtime" />
-    <PackageReference Include="Grasshopper" Version="9.0.26135.9190-dujour" />
-    <PackageReference Include="Grasshopper2" Version="9.0.26135.9190-dujour" />
+    <PackageReference Include="RhinoCommon" Version="9.0.26132.12305-wip" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="9.0.26132.12305-wip" />
+    <PackageReference Include="Grasshopper2" Version="9.0.26132.12305-wip" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R8'">

--- a/rhino/plugin/RhMcp.csproj
+++ b/rhino/plugin/RhMcp.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R9'">
-    <PackageReference Include="RhinoCommon" Version="9.0.26132.12305-wip" ExcludeAssets="runtime" />
-    <PackageReference Include="Grasshopper" Version="9.0.26132.12305-wip" />
-    <PackageReference Include="Grasshopper2" Version="9.0.26132.12305-wip" />
+    <PackageReference Include="RhinoCommon" Version="9.0.26135.9190-dujour" ExcludeAssets="runtime" />
+    <PackageReference Include="Grasshopper" Version="9.0.26135.9190-dujour" />
+    <PackageReference Include="Grasshopper2" Version="9.0.26135.9190-dujour" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RhinoTarget)' == 'R8'">

--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -1,5 +1,8 @@
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
+
+using Rhino.FileIO;
 
 namespace RhMcp;
 
@@ -101,15 +104,57 @@ public static class RhinoMcpHost
         }
     }
 
-    // Stop the listener bound to the given port, regardless of doc. Used by the
-    // router's control channel on Mac to tear down a single slot without
-    // affecting other slots sharing the same Rhino process.
+    // Stop the listener bound to the given port and close its associated doc
+    // without keeping any save artefacts. Used by the router's control channel
+    // on Mac to tear down a single slot without affecting other slots sharing
+    // the same Rhino process. The router only calls this for slots it spawned
+    // (adopted slots are refused upstream), so discarding the doc is safe.
+    //
+    // Mac's `_-Close` command matches docs by their on-disk path (see
+    // src4/rhino4/commands/cmdFileIO.cpp) and is the only way to programmatically
+    // close a non-headless doc — RhinoDoc.Dispose is a no-op for them. We give
+    // the doc a temp path via WriteFile so the command can find it, then delete
+    // that file once Cocoa's deferred close has run.
     public static bool StopByPort(int port)
     {
         var entry = Servers.FirstOrDefault(kv => kv.Value.Port == port);
         if (entry.Value is null) return false;
-        Servers.Remove(entry.Key);
+        var docSerial = entry.Key;
+        Servers.Remove(docSerial);
         entry.Value.Stop();
+
+        var doc = RhinoDoc.FromRuntimeSerialNumber(docSerial);
+        if (doc is null) return true;
+
+        var tempPath = Path.Combine(
+            Path.GetTempPath(),
+            $"rh-mcp-slot-close-{docSerial}-{Guid.NewGuid():N}.3dm");
+        try
+        {
+            doc.Modified = false;
+            doc.WriteFile(tempPath, new FileWriteOptions
+            {
+                SuppressDialogBoxes = true,
+                WriteUserData = true,
+                UpdateDocumentPath = true,
+            });
+            RhinoApp.RunScript(docSerial, $"_-Close \"{tempPath}\"", false);
+        }
+        catch (Exception ex)
+        {
+            RhinoApp.WriteLine($"[Rhino MCP] Slot doc close failed for port {port}: {ex.Message}");
+            return true;
+        }
+
+        // Mac defers the doc close via Cocoa performSelector:afterDelay:0.1.
+        // Wait past that, then delete the temp file. Fire-and-forget — we
+        // don't want to block the router's HTTP response.
+        _ = Task.Run(async () =>
+        {
+            await Task.Delay(1000).ConfigureAwait(false);
+            try { File.Delete(tempPath); } catch { /* OS temp sweep will get it */ }
+        });
+
         return true;
     }
 }

--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -54,7 +54,7 @@ public static class RhinoMcpHost
         return true;
     }
 
-    // Drop a one-shot announcement into <temp>/rhino-mcp-listeners/ so a router
+    // Drop a one-shot announcement into <temp>/rhino-mcp/listeners/ so a router
     // running on this machine can discover and adopt this listener without us
     // having to know whether one is up. The router consumes (probes + deletes)
     // the file on its next scan; if no router ever sees it, temp sweep collects
@@ -63,7 +63,7 @@ public static class RhinoMcpHost
     {
         try
         {
-            var dir = Path.Combine(Path.GetTempPath(), "rhino-mcp-listeners");
+            var dir = Path.Combine(Path.GetTempPath(), "rhino-mcp", "listeners");
             Directory.CreateDirectory(dir);
             var pid = Process.GetCurrentProcess().Id;
             var version = RhinoApp.Version.Major.ToString();

--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -54,7 +54,28 @@ public static class RhinoMcpHost
         return true;
     }
 
-    // Drop a one-shot announcement into <temp>/rhino-mcp/listeners/ so a router
+    // Shared dispatch for both the interactive `RhinoMCP` command and the
+    // hidden `StartMCP` autostart path. Writes user-facing status lines.
+    public static bool StartOrRestart(RhinoDoc doc, int port)
+    {
+        if (HasStarted(doc))
+        {
+            if (!RestartOnPort(doc, port))
+            {
+                RhinoApp.WriteLine($"[Rhino MCP] Failed to bind port {port}.");
+                return false;
+            }
+            RhinoApp.WriteLine($"[Rhino MCP] Restarted on http://localhost:{port}/");
+            return true;
+        }
+
+        if (Start(doc, port)) return true;
+
+        RhinoApp.WriteLine($"[Rhino MCP] MCP server failed to start. Try a different port.");
+        return false;
+    }
+
+    // Drop a one-shot announcement into <temp>/rhino-mcp-listeners/ so a router
     // running on this machine can discover and adopt this listener without us
     // having to know whether one is up. The router consumes (probes + deletes)
     // the file on its next scan; if no router ever sees it, temp sweep collects

--- a/rhino/plugin/RhinoLoggerProvider.cs
+++ b/rhino/plugin/RhinoLoggerProvider.cs
@@ -11,7 +11,13 @@ internal sealed class RhinoLoggerProvider : ILoggerProvider
     {
         private string Category { get; } = category;
 
-        public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Information;
+        public bool IsEnabled(LogLevel logLevel) => logLevel >= MinLevel;
+
+#if DEBUG
+        private const LogLevel MinLevel = LogLevel.Information;
+#else
+        private const LogLevel MinLevel = LogLevel.Warning;
+#endif
 
         public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
             Exception? exception, Func<TState, Exception?, string> formatter)

--- a/rhino/plugin/StartMCPCommand.cs
+++ b/rhino/plugin/StartMCPCommand.cs
@@ -1,0 +1,31 @@
+using Rhino.Commands;
+
+namespace RhMcp;
+
+// Hidden autostart entry point invoked by the router via `-runscript=_-StartMCP _Enter`.
+// The port arrives via the RHINO_MCP_AUTOSTART_PORT env var so we don't have to feed
+// arguments through the runscript engine — that path is racy with plugin load timing.
+[CommandStyle(Style.ScriptRunner | Style.Hidden)]
+public class StartMCPCommand : Command
+{
+
+    public const string PortEnvVar = "RHINO_MCP_AUTOSTART_PORT";
+
+    public override string EnglishName => "StartMCP";
+
+    protected override Result RunCommand(RhinoDoc doc, RunMode mode)
+    {
+        string? portStr = Environment.GetEnvironmentVariable(PortEnvVar);
+        if (!int.TryParse(portStr, out int port) || port < 1 || port > 65535)
+        {
+            RhinoApp.WriteLine($"[Rhino MCP] StartMCP: {PortEnvVar} not set or invalid (got '{portStr}').");
+            return Result.Failure;
+        }
+        
+        // Obfuscate the StartMCP command a little.
+        RhinoApp.ClearCommandHistoryWindow();
+
+        return RhinoMcpHost.StartOrRestart(doc, port) ? Result.Success : Result.Failure;
+    }
+
+}

--- a/rhino/plugin/Tools/CloseDocTool.cs
+++ b/rhino/plugin/Tools/CloseDocTool.cs
@@ -1,0 +1,35 @@
+using Rhino.FileIO;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class CloseDocTool
+{
+    [McpServerTool(Name = "close_doc")]
+    [Description("Close the current Rhino document. If path is given, save to that .3dm path first; otherwise discard unsaved changes.")]
+    public static string CloseDoc(
+        RhinoDoc doc,
+        [Description("Optional absolute .3dm path to save to before closing. Omit to close without saving.")] string? path = null)
+    {
+        if (!string.IsNullOrWhiteSpace(path))
+        {
+            var dir = System.IO.Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir) && !System.IO.Directory.Exists(dir))
+                throw new System.IO.DirectoryNotFoundException($"Directory does not exist: {dir}");
+
+            var options = new FileWriteOptions
+            {
+                SuppressDialogBoxes = true,
+                WriteUserData = true,
+                UpdateDocumentPath = true,
+            };
+
+            if (!doc.WriteFile(path, options))
+                throw new InvalidOperationException($"Failed to save: {path}");
+        }
+
+        doc.Modified = false;
+        RhinoApp.RunScript(doc.RuntimeSerialNumber, "_-Close", false);
+        return path is null ? "Document closed without saving." : $"Document saved to {path} and closed.";
+    }
+}

--- a/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
@@ -43,49 +43,46 @@ public static class GH1_ApplyGraphTool
         var placeErrors = new List<PlaceError>();
         var wireResults = new WireResult[wires?.Length ?? 0];
 
-        RhinoApp.InvokeAndWait(() =>
+        if (sliders is not null)
         {
-            if (sliders is not null)
+            foreach (var s in sliders)
             {
-                foreach (var s in sliders)
+                if (TryPlaceSlider(doc, s, out var slider, out var err))
                 {
-                    if (TryPlaceSlider(doc, s, out var slider, out var err))
-                    {
-                        keyToObj[s.Key] = slider!;
-                        placed.Add(new PlacedRef(s.Key, slider!.InstanceGuid, "Slider"));
-                    }
-                    else
-                    {
-                        placeErrors.Add(new PlaceError(s.Key, err));
-                    }
+                    keyToObj[s.Key] = slider!;
+                    placed.Add(new PlacedRef(s.Key, slider!.InstanceGuid, "Slider"));
+                }
+                else
+                {
+                    placeErrors.Add(new PlaceError(s.Key, err));
                 }
             }
+        }
 
-            if (components is not null)
+        if (components is not null)
+        {
+            foreach (var c in components)
             {
-                foreach (var c in components)
+                if (TryPlaceComponent(doc, c, out var obj, out var err))
                 {
-                    if (TryPlaceComponent(doc, c, out var obj, out var err))
-                    {
-                        keyToObj[c.Key] = obj!;
-                        placed.Add(new PlacedRef(c.Key, obj!.InstanceGuid, GH1_Utils.ClassifyKind(obj.GetType())));
-                    }
-                    else
-                    {
-                        placeErrors.Add(new PlaceError(c.Key, err));
-                    }
+                    keyToObj[c.Key] = obj!;
+                    placed.Add(new PlacedRef(c.Key, obj!.InstanceGuid, GH1_Utils.ClassifyKind(obj.GetType())));
+                }
+                else
+                {
+                    placeErrors.Add(new PlaceError(c.Key, err));
                 }
             }
+        }
 
-            if (wires is not null)
-            {
-                for (int i = 0; i < wires.Length; i++)
-                    wireResults[i] = WireOne(i, wires[i], keyToObj);
-            }
+        if (wires is not null)
+        {
+            for (int i = 0; i < wires.Length; i++)
+                wireResults[i] = WireOne(i, wires[i], keyToObj);
+        }
 
-            if (solve) doc.NewSolution(false);
-            GH1_Utils.Redraw();
-        });
+        if (solve) doc.NewSolution(false);
+        GH1_Utils.Redraw();
 
         int wiresOk = 0;
         for (int i = 0; i < wireResults.Length; i++) if (wireResults[i].Ok) wiresOk++;

--- a/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
@@ -29,13 +29,13 @@ public static class GH1_ApplyGraphTool
     [McpServerTool(Name = "g1_apply_graph")]
     [Description("Place sliders + components and wire them in one call. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'g1_connect'.")]
     public static string Apply(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Sliders to place: {Key, Min, Value, Max, Type, Name?, X, Y}. Type ∈ 'float'|'int'|'even'|'odd'.")] SliderSpec[] sliders,
         [Description("Components to place: {Key, Selector, X, Y}. Selector is a Guid (preferred — avoids name ambiguity) or component Name.")] ComponentSpec[] components,
         [Description("Wires to create: {SrcKey, Src, DstKey, Dst}. Keys must match a slider or component key above.")] WireSpec[] wires,
         [Description("If true, trigger a new solution at the end.")] bool solve = true)
     {
-        if (!GH1_Utils.TryGetOrCreateDoc(out GH_Document doc))
+        if (!GH1_Utils.TryGetOrCreateDoc(rhDoc, out GH_Document doc))
             return "Could not get or create GH document";
 
         var keyToObj = new Dictionary<string, IGH_DocumentObject>(StringComparer.Ordinal);

--- a/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ApplyGraphTool.cs
@@ -26,8 +26,8 @@ public static class GH1_ApplyGraphTool
         WireResult[] Wires,
         int WiresOk);
 
-    [McpServerTool(Name = "apply_graph")]
-    [Description("Place sliders + components and wire them in one call. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'connect'.")]
+    [McpServerTool(Name = "g1_apply_graph")]
+    [Description("Place sliders + components and wire them in one call. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'g1_connect'.")]
     public static string Apply(
         RhinoDoc _,
         [Description("Sliders to place: {Key, Min, Value, Max, Type, Name?, X, Y}. Type ∈ 'float'|'int'|'even'|'odd'.")] SliderSpec[] sliders,

--- a/rhino/plugin/Tools/GH1/GH1_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ClearCanvasTool.cs
@@ -24,12 +24,9 @@ public static class GH1_ClearCanvasTool
         var snapshot = doc.Objects.ToList();
         int count = snapshot.Count;
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            doc.RemoveObjects(snapshot, false);
-            if (solve) doc.NewSolution(true);
-            GH1_Utils.Redraw();
-        });
+        doc.RemoveObjects(snapshot, false);
+        if (solve) doc.NewSolution(true);
+        GH1_Utils.Redraw();
 
         return JsonSerializer.Serialize(new ClearResult(count));
     }

--- a/rhino/plugin/Tools/GH1/GH1_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ClearCanvasTool.cs
@@ -9,7 +9,7 @@ public static class GH1_ClearCanvasTool
 {
     public record struct ClearResult(int Removed);
 
-    [McpServerTool(Name = "clear_canvas")]
+    [McpServerTool(Name = "g1_clear_canvas")]
     [Description("Remove every object from the active GH1 canvas. Destructive — requires confirm=true.")]
     public static string Clear(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ConnectManyTool.cs
@@ -26,14 +26,11 @@ public static class GH1_ConnectManyTool
 
         var results = new WireResult[wires.Length];
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            for (int i = 0; i < wires.Length; i++)
-                results[i] = WireOne(doc, i, wires[i]);
+        for (int i = 0; i < wires.Length; i++)
+            results[i] = WireOne(doc, i, wires[i]);
 
-            if (solve) doc.NewSolution(false);
-            GH1_Utils.Redraw();
-        });
+        if (solve) doc.NewSolution(false);
+        GH1_Utils.Redraw();
 
         int okCount = 0;
         for (int i = 0; i < results.Length; i++) if (results[i].Ok) okCount++;

--- a/rhino/plugin/Tools/GH1/GH1_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ConnectManyTool.cs
@@ -12,8 +12,8 @@ public static class GH1_ConnectManyTool
     public record struct WireResult(int Index, bool Ok, Endpoint? Src, Endpoint? Dst, string? Error);
     public record struct BatchResult(int Count, int OkCount, WireResult[] Wires);
 
-    [McpServerTool(Name = "connect_many")]
-    [Description("Wire multiple output→input connections in one call. Same selector semantics as 'connect' (numeric index or Name/NickName; '' or '0' for pure params). A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
+    [McpServerTool(Name = "g1_connect_many")]
+    [Description("Wire multiple output→input connections in one call. Same selector semantics as 'g1_connect' (numeric index or Name/NickName; '' or '0' for pure params). A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
     public static string ConnectMany(
         RhinoDoc _,
         [Description("Array of {SrcId, Src, DstId, Dst} wire descriptors.")] WireSpec[] wires,

--- a/rhino/plugin/Tools/GH1/GH1_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ConnectTool.cs
@@ -47,12 +47,9 @@ public static class GH1_ConnectTool
 
         try
         {
-            RhinoApp.InvokeAndWait(() =>
-            {
-                dstParam!.AddSource(srcParam);
-                if (solve) doc.NewSolution(false);
-                GH1_Utils.Redraw();
-            });
+            dstParam!.AddSource(srcParam);
+            if (solve) doc.NewSolution(false);
+            GH1_Utils.Redraw();
         }
         catch (Exception ex)
         {

--- a/rhino/plugin/Tools/GH1/GH1_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_ConnectTool.cs
@@ -11,7 +11,7 @@ public static class GH1_ConnectTool
     public record struct OkResult(bool Ok, Endpoint Src, Endpoint Dst);
     public record struct ErrResult(bool Ok, string Error);
 
-    [McpServerTool(Name = "connect")]
+    [McpServerTool(Name = "g1_connect")]
     [Description("Wire an output parameter to an input parameter on the active GH1 canvas. 'src' and 'dst' may be a numeric index or a Name/NickName. For pure params (e.g. a slider) pass '' or '0'.")]
     public static string Connect(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_DescribeComponentTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_DescribeComponentTool.cs
@@ -20,7 +20,7 @@ public static class GH1_DescribeComponentTool
         ParamInfo[] Inputs,
         ParamInfo[] Outputs);
 
-    [McpServerTool(Name = "describe_component")]
+    [McpServerTool(Name = "g1_describe_component")]
     [Description("Look up a Grasshopper component by name and return its category, description, and input/output parameter list. Useful before placing or wiring components.")]
     public static string Describe(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_GetCanvasGraphTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_GetCanvasGraphTool.cs
@@ -32,7 +32,7 @@ public static class GH1_GetCanvasGraphTool
     public record struct Wire(Endpoint From, Endpoint To);
     public record struct Graph(ObjectInfo[] Objects, Wire[] Wires);
 
-    [McpServerTool(Name = "get_canvas_graph")]
+    [McpServerTool(Name = "g1_get_canvas_graph")]
     [Description("Return a structured snapshot of the active GH1 canvas: objects (with messages, inputs/outputs and optional volatile data summaries) and wires between them.")]
     public static string GetGraph(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
@@ -60,12 +60,9 @@ public static class GH1_PlaceComponentTool
         if (obj.Attributes is null) return $"Failed to create attributes for '{selector}'";
         obj.Attributes.Pivot = new PointF(x, y);
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            doc.AddObject(obj, false);
-            if (solve) doc.NewSolution(false);
-            GH1_Utils.ZoomExtents();
-        });
+        doc.AddObject(obj, false);
+        if (solve) doc.NewSolution(false);
+        GH1_Utils.ZoomExtents();
 
         return JsonSerializer.Serialize(new PlacedInfo(
             obj.InstanceGuid,

--- a/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
@@ -17,13 +17,13 @@ public static class GH1_PlaceComponentTool
     [McpServerTool(Name = "g1_place_component")]
     [Description("Place a Grasshopper component onto the active GH1 canvas. 'selector' may be a Guid (proxy id) or a component name. If multiple components share the name, returns an ambiguity payload listing candidates.")]
     public static string Place(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Component Guid (proxy id) or component Name (case-insensitive).")] string selector,
         [Description("Canvas X position in pixels.")] float x = 100,
         [Description("Canvas Y position in pixels.")] float y = 100,
         [Description("If true, trigger a new solution after placing. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
     {
-        if (!GH1_Utils.TryGetOrCreateDoc(out GH_Document doc))
+        if (!GH1_Utils.TryGetOrCreateDoc(rhDoc, out GH_Document doc))
             return "Could not get or create GH document";
 
         IGH_DocumentObject? obj;

--- a/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceComponentTool.cs
@@ -14,7 +14,7 @@ public static class GH1_PlaceComponentTool
     public record struct Candidate(Guid Guid, string Name, string Category, string SubCategory);
     public record struct AmbiguousResult(string Error, Candidate[] Candidates);
 
-    [McpServerTool(Name = "place_component")]
+    [McpServerTool(Name = "g1_place_component")]
     [Description("Place a Grasshopper component onto the active GH1 canvas. 'selector' may be a Guid (proxy id) or a component name. If multiple components share the name, returns an ambiguity payload listing candidates.")]
     public static string Place(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
@@ -16,7 +16,7 @@ public static class GH1_PlaceSliderTool
     [McpServerTool(Name = "g1_place_slider")]
     [Description("Place a Number Slider on the active GH1 canvas with the given range and current value. type: 'float' | 'int' | 'even' | 'odd'.")]
     public static string Place(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Minimum slider value.")] double min,
         [Description("Initial slider value.")] double value,
         [Description("Maximum slider value.")] double max,
@@ -29,7 +29,7 @@ public static class GH1_PlaceSliderTool
         if (!TryParseAccuracy(type, out GH_SliderAccuracy accuracy))
             return $"Invalid type '{type}'. Valid values: 'float', 'int', 'even', 'odd'.";
 
-        if (!GH1_Utils.TryGetOrCreateDoc(out GH_Document doc))
+        if (!GH1_Utils.TryGetOrCreateDoc(rhDoc, out GH_Document doc))
             return "Could not get or create GH document";
 
         var slider = new GH_NumberSlider();

--- a/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
@@ -44,12 +44,9 @@ public static class GH1_PlaceSliderTool
 
         slider.Attributes.Pivot = new PointF(x, y);
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            doc.AddObject(slider, false);
-            if (solve) doc.NewSolution(false);
-            GH1_Utils.ZoomExtents();
-        });
+        doc.AddObject(slider, false);
+        if (solve) doc.NewSolution(false);
+        GH1_Utils.ZoomExtents();
 
         return JsonSerializer.Serialize(new SliderInfo(
             slider.InstanceGuid,

--- a/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_PlaceSliderTool.cs
@@ -13,7 +13,7 @@ public static class GH1_PlaceSliderTool
 {
     public record struct SliderInfo(Guid Id, double Min, double Value, double Max, string Type, float X, float Y);
 
-    [McpServerTool(Name = "place_slider")]
+    [McpServerTool(Name = "g1_place_slider")]
     [Description("Place a Number Slider on the active GH1 canvas with the given range and current value. type: 'float' | 'int' | 'even' | 'odd'.")]
     public static string Place(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_SearchComponentsTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_SearchComponentsTool.cs
@@ -17,7 +17,7 @@ public static class GH1_SearchComponentsTool
         string Kind,
         string Description);
 
-    [McpServerTool(Name = "search_components")]
+    [McpServerTool(Name = "g1_search_components")]
     [Description("Search the Grasshopper component library by substring. Matches Name, NickName, and Description (case-insensitive). Optional exact-match category/subcategory filters. Returns up to 'limit' matches.")]
     public static string Search(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
@@ -14,7 +14,7 @@ public static class GH1_SolveTool
         RhinoDoc rhinoDoc,
         [Description("Auto-zoom every Rhino viewport to the GH preview after solving. true=always, false=never, null=zoom only when nothing was visible pre-solve.")] bool? zoom_views = null)
     {
-        if (!GH1_Utils.TryGetOrCreateDoc(out GH_Document ghDoc)) return "Could not get GHDoc";
+        if (!GH1_Utils.TryGetOrCreateDoc(rhinoDoc, out GH_Document ghDoc)) return "Could not get GHDoc";
 
         int activeCount = ghDoc.ActiveObjects().Count;
         if (activeCount <= 0)

--- a/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
@@ -27,13 +27,10 @@ public static class GH1_SolveTool
 
         try
         {
-            RhinoApp.InvokeAndWait(() =>
-            {
-                ghDoc.NewSolution(true);
+            ghDoc.NewSolution(true);
 
-                bool shouldZoom = zoom_views ?? !wasPreviewVisible;
-                if (shouldZoom) ZoomViewsToPreview(rhinoDoc, ghDoc);
-            });
+            bool shouldZoom = zoom_views ?? !wasPreviewVisible;
+            if (shouldZoom) ZoomViewsToPreview(rhinoDoc, ghDoc);
         }
         catch (Exception ex)
         {

--- a/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
+++ b/rhino/plugin/Tools/GH1/GH1_SolveTool.cs
@@ -8,7 +8,7 @@ namespace RhMcp.Tools;
 [McpServerToolType]
 public static class GH1_SolveTool
 {
-    [McpServerTool(Name = "solve_graph")]
+    [McpServerTool(Name = "g1_solve_graph")]
     [Description("Solves the active GH canvas. zoom_views controls whether Rhino viewports zoom to the new preview: true=always, false=never, null=auto (zoom only when nothing was previewed before the solve).")]
     public static string Solve(
         RhinoDoc rhinoDoc,

--- a/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
@@ -44,49 +44,46 @@ public static class GH2_ApplyGraphTool
         var placeErrors = new List<PlaceError>();
         var wireResults = new WireResult[wires?.Length ?? 0];
 
-        RhinoApp.InvokeAndWait(() =>
+        if (sliders is not null)
         {
-            if (sliders is not null)
+            foreach (var s in sliders)
             {
-                foreach (var s in sliders)
+                if (TryPlaceSlider(doc, s, out var slider, out var err))
                 {
-                    if (TryPlaceSlider(doc, s, out var slider, out var err))
-                    {
-                        keyToObj[s.Key] = slider!;
-                        placed.Add(new PlacedRef(s.Key, slider!.InstanceId, "Slider"));
-                    }
-                    else
-                    {
-                        placeErrors.Add(new PlaceError(s.Key, err));
-                    }
+                    keyToObj[s.Key] = slider!;
+                    placed.Add(new PlacedRef(s.Key, slider!.InstanceId, "Slider"));
+                }
+                else
+                {
+                    placeErrors.Add(new PlaceError(s.Key, err));
                 }
             }
+        }
 
-            if (components is not null)
+        if (components is not null)
+        {
+            foreach (var c in components)
             {
-                foreach (var c in components)
+                if (TryPlaceComponent(doc, c, out var obj, out var err))
                 {
-                    if (TryPlaceComponent(doc, c, out var obj, out var err))
-                    {
-                        keyToObj[c.Key] = obj!;
-                        placed.Add(new PlacedRef(c.Key, obj!.InstanceId, GH2_Utils.ClassifyKind(obj.GetType())));
-                    }
-                    else
-                    {
-                        placeErrors.Add(new PlaceError(c.Key, err));
-                    }
+                    keyToObj[c.Key] = obj!;
+                    placed.Add(new PlacedRef(c.Key, obj!.InstanceId, GH2_Utils.ClassifyKind(obj.GetType())));
+                }
+                else
+                {
+                    placeErrors.Add(new PlaceError(c.Key, err));
                 }
             }
+        }
 
-            if (wires is not null)
-            {
-                for (int i = 0; i < wires.Length; i++)
-                    wireResults[i] = WireOne(i, wires[i], keyToObj);
-            }
+        if (wires is not null)
+        {
+            for (int i = 0; i < wires.Length; i++)
+                wireResults[i] = WireOne(i, wires[i], keyToObj);
+        }
 
-            if (solve) doc.Solution.Start();
-            GH2_Utils.Redraw();
-        });
+        if (solve) doc.Solution.Start();
+        GH2_Utils.Redraw();
 
         int wiresOk = 0;
         for (int i = 0; i < wireResults.Length; i++) if (wireResults[i].Ok) wiresOk++;

--- a/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
@@ -30,13 +30,13 @@ public static class GH2_ApplyGraphTool
     [McpServerTool(Name = "g2_apply_graph")]
     [Description("Place sliders + components and wire them in one call on the active GH2 canvas. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'g2_connect'.")]
     public static string Apply(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Sliders to place: {Key, Min, Value, Max, Decimals, Name?, X, Y}. Decimals: 0..12.")] SliderSpec[] sliders,
         [Description("Components to place: {Key, Selector, X, Y}. Selector is a Guid (preferred) or component Name.")] ComponentSpec[] components,
         [Description("Wires to create: {SrcKey, Src, DstKey, Dst}. Keys must match a slider or component key above.")] WireSpec[] wires,
         [Description("If true, trigger a new solution at the end.")] bool solve = true)
     {
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "Could not get or create GH2 document";
 
         var keyToObj = new Dictionary<string, IDocumentObject>(StringComparer.Ordinal);

--- a/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
@@ -1,0 +1,173 @@
+using RhMcp.Resources;
+
+using Eto.Drawing;
+
+using Grasshopper2.Doc;
+using Grasshopper2.Framework;
+using Grasshopper2.Parameters;
+using Grasshopper2.Parameters.Special;
+using Grasshopper2.UI;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_ApplyGraphTool
+{
+    public record struct ComponentSpec(string Key, string Selector, float X, float Y);
+    public record struct SliderSpec(string Key, double Min, double Value, double Max, int Decimals, string? Name, float X, float Y);
+    public record struct WireSpec(string SrcKey, string Src, string DstKey, string Dst);
+
+    public record struct PlacedRef(string Key, Guid Id, string Kind);
+    public record struct PlaceError(string Key, string Error);
+    public record struct WireResult(int Index, bool Ok, string? Error);
+
+    public record struct ApplyResult(
+        PlacedRef[] Placed,
+        PlaceError[] PlaceErrors,
+        WireResult[] Wires,
+        int WiresOk);
+
+    [McpServerTool(Name = "apply_graph")]
+    [Description("Place sliders + components and wire them in one call on the active GH2 canvas. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'connect'.")]
+    public static string Apply(
+        RhinoDoc _,
+        [Description("Sliders to place: {Key, Min, Value, Max, Decimals, Name?, X, Y}. Decimals: 0..12.")] SliderSpec[] sliders,
+        [Description("Components to place: {Key, Selector, X, Y}. Selector is a Guid (preferred) or component Name.")] ComponentSpec[] components,
+        [Description("Wires to create: {SrcKey, Src, DstKey, Dst}. Keys must match a slider or component key above.")] WireSpec[] wires,
+        [Description("If true, trigger a new solution at the end.")] bool solve = true)
+    {
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "Could not get or create GH2 document";
+
+        var keyToObj = new Dictionary<string, IDocumentObject>(StringComparer.Ordinal);
+        var placed = new List<PlacedRef>();
+        var placeErrors = new List<PlaceError>();
+        var wireResults = new WireResult[wires?.Length ?? 0];
+
+        RhinoApp.InvokeAndWait(() =>
+        {
+            if (sliders is not null)
+            {
+                foreach (var s in sliders)
+                {
+                    if (TryPlaceSlider(doc, s, out var slider, out var err))
+                    {
+                        keyToObj[s.Key] = slider!;
+                        placed.Add(new PlacedRef(s.Key, slider!.InstanceId, "Slider"));
+                    }
+                    else
+                    {
+                        placeErrors.Add(new PlaceError(s.Key, err));
+                    }
+                }
+            }
+
+            if (components is not null)
+            {
+                foreach (var c in components)
+                {
+                    if (TryPlaceComponent(doc, c, out var obj, out var err))
+                    {
+                        keyToObj[c.Key] = obj!;
+                        placed.Add(new PlacedRef(c.Key, obj!.InstanceId, GH2_Utils.ClassifyKind(obj.GetType())));
+                    }
+                    else
+                    {
+                        placeErrors.Add(new PlaceError(c.Key, err));
+                    }
+                }
+            }
+
+            if (wires is not null)
+            {
+                for (int i = 0; i < wires.Length; i++)
+                    wireResults[i] = WireOne(i, wires[i], keyToObj);
+            }
+
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
+        });
+
+        int wiresOk = 0;
+        for (int i = 0; i < wireResults.Length; i++) if (wireResults[i].Ok) wiresOk++;
+
+        return JsonSerializer.Serialize(new ApplyResult(
+            placed.ToArray(),
+            placeErrors.ToArray(),
+            wireResults,
+            wiresOk));
+    }
+
+    private static bool TryPlaceSlider(Document doc, SliderSpec s, out NumberSliderObject? slider, out string error)
+    {
+        slider = null;
+        if (s.Decimals < 0 || s.Decimals > 12)
+        {
+            error = $"Invalid decimals '{s.Decimals}'. Valid range: 0..12.";
+            return false;
+        }
+
+        var number = new UiNumber(s.Decimals, (decimal)s.Value, (decimal)s.Min, (decimal)s.Max);
+        slider = new NumberSliderObject(string.IsNullOrEmpty(s.Name) ? "num" : s.Name!, number);
+        doc.Objects.Add(slider, new PointF(s.X, s.Y));
+        error = "";
+        return true;
+    }
+
+    private static bool TryPlaceComponent(Document doc, ComponentSpec c, out IDocumentObject? obj, out string error)
+    {
+        obj = null;
+        if (Guid.TryParse(c.Selector, out Guid guid))
+        {
+            var proxy = ObjectProxies.FindById(guid);
+            if (proxy is null) { error = $"No component with guid '{guid}'"; return false; }
+            obj = proxy.Emit();
+            if (obj is null) { error = $"Failed to emit '{guid}'"; return false; }
+        }
+        else
+        {
+            var matches = new List<ObjectProxy>();
+            foreach (var p in ObjectProxies.Proxies)
+                if (string.Equals(p.Nomen.Name, c.Selector, StringComparison.OrdinalIgnoreCase))
+                    matches.Add(p);
+
+            if (matches.Count == 0) { error = $"No component named '{c.Selector}'"; return false; }
+            if (matches.Count > 1)
+            {
+                var names = string.Join(", ", matches.Select(p => $"{p.Id} ({p.Nomen.Chapter}/{p.Nomen.Section})"));
+                error = $"Component name '{c.Selector}' is ambiguous ({matches.Count} matches): {names}. Pass a Guid to disambiguate.";
+                return false;
+            }
+            obj = matches[0].Emit();
+            if (obj is null) { error = $"Failed to instantiate '{c.Selector}'"; return false; }
+        }
+        doc.Objects.Add(obj, new PointF(c.X, c.Y));
+        error = "";
+        return true;
+    }
+
+    private static WireResult WireOne(int idx, WireSpec w, Dictionary<string, IDocumentObject> keyToObj)
+    {
+        if (!keyToObj.TryGetValue(w.SrcKey, out var srcObj))
+            return new WireResult(idx, false, $"src_key '{w.SrcKey}' did not match a placed object");
+        if (!keyToObj.TryGetValue(w.DstKey, out var dstObj))
+            return new WireResult(idx, false, $"dst_key '{w.DstKey}' did not match a placed object");
+
+        if (!GH2_GraphOps.TryResolveOutput(srcObj, w.Src, out IParameter? srcParam, out string srcErr))
+            return new WireResult(idx, false, srcErr);
+        if (!GH2_GraphOps.TryResolveInput(dstObj, w.Dst, out IParameter? dstParam, out string dstErr))
+            return new WireResult(idx, false, dstErr);
+
+        try
+        {
+            if (dstParam!.Inputs.IndexOf(srcParam!.InstanceId) < 0)
+                Connections.Connect(srcParam!, dstParam!);
+        }
+        catch (Exception ex)
+        {
+            return new WireResult(idx, false, ex.Message);
+        }
+
+        return new WireResult(idx, true, null);
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ApplyGraphTool.cs
@@ -27,8 +27,8 @@ public static class GH2_ApplyGraphTool
         WireResult[] Wires,
         int WiresOk);
 
-    [McpServerTool(Name = "apply_graph")]
-    [Description("Place sliders + components and wire them in one call on the active GH2 canvas. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'connect'.")]
+    [McpServerTool(Name = "g2_apply_graph")]
+    [Description("Place sliders + components and wire them in one call on the active GH2 canvas. References between objects use caller-supplied 'key' strings; the tool returns the key→Guid map. Failures in any step do not abort the rest; results report per-step status. Wire src/dst use the same selector semantics as 'g2_connect'.")]
     public static string Apply(
         RhinoDoc _,
         [Description("Sliders to place: {Key, Min, Value, Max, Decimals, Name?, X, Y}. Decimals: 0..12.")] SliderSpec[] sliders,

--- a/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
@@ -1,0 +1,38 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Doc;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_ClearCanvasTool
+{
+    public record struct ClearResult(int Removed);
+
+    [McpServerTool(Name = "clear_canvas")]
+    [Description("Remove every object from the active GH2 canvas. Destructive — requires confirm=true.")]
+    public static string Clear(
+        RhinoDoc _,
+        [Description("Must be true to actually wipe the canvas. Defaults to false as a safety guard.")] bool confirm = false,
+        [Description("If true, trigger a new solution after clearing.")] bool solve = true)
+    {
+        if (!confirm) return "Refused: pass confirm=true to wipe the canvas.";
+
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "Could not get GH2 document";
+
+        var snapshot = doc.Objects.Forwards.ToList();
+        int count = snapshot.Count;
+
+        RhinoApp.InvokeAndWait(() =>
+        {
+            foreach (var obj in snapshot)
+                doc.Objects.Remove(obj.InstanceId);
+
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
+        });
+
+        return JsonSerializer.Serialize(new ClearResult(count));
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
@@ -24,14 +24,11 @@ public static class GH2_ClearCanvasTool
         var snapshot = doc.Objects.Forwards.ToList();
         int count = snapshot.Count;
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            foreach (var obj in snapshot)
-                doc.Objects.Remove(obj.InstanceId);
+        foreach (var obj in snapshot)
+            doc.Objects.Remove(obj.InstanceId);
 
-            if (solve) doc.Solution.Start();
-            GH2_Utils.Redraw();
-        });
+        if (solve) doc.Solution.Start();
+        GH2_Utils.Redraw();
 
         return JsonSerializer.Serialize(new ClearResult(count));
     }

--- a/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
@@ -12,13 +12,13 @@ public static class GH2_ClearCanvasTool
     [McpServerTool(Name = "g2_clear_canvas")]
     [Description("Remove every object from the active GH2 canvas. Destructive — requires confirm=true.")]
     public static string Clear(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Must be true to actually wipe the canvas. Defaults to false as a safety guard.")] bool confirm = false,
         [Description("If true, trigger a new solution after clearing.")] bool solve = true)
     {
         if (!confirm) return "Refused: pass confirm=true to wipe the canvas.";
 
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "Could not get GH2 document";
 
         var snapshot = doc.Objects.Forwards.ToList();

--- a/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ClearCanvasTool.cs
@@ -9,7 +9,7 @@ public static class GH2_ClearCanvasTool
 {
     public record struct ClearResult(int Removed);
 
-    [McpServerTool(Name = "clear_canvas")]
+    [McpServerTool(Name = "g2_clear_canvas")]
     [Description("Remove every object from the active GH2 canvas. Destructive — requires confirm=true.")]
     public static string Clear(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
@@ -1,0 +1,78 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Doc;
+using Grasshopper2.Parameters;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_ConnectManyTool
+{
+    public record struct WireSpec(string SrcId, string Src, string DstId, string Dst);
+    public record struct Endpoint(Guid Id, string Param);
+    public record struct WireResult(int Index, bool Ok, Endpoint? Src, Endpoint? Dst, string? Error);
+    public record struct BatchResult(int Count, int OkCount, WireResult[] Wires);
+
+    [McpServerTool(Name = "connect_many")]
+    [Description("Wire multiple output→input connections in one call on the active GH2 canvas. Same selector semantics as 'connect'. A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
+    public static string ConnectMany(
+        RhinoDoc _,
+        [Description("Array of {SrcId, Src, DstId, Dst} wire descriptors.")] WireSpec[] wires,
+        [Description("If true, trigger a new solution after wiring. Set false to batch further.")] bool solve = true)
+    {
+        if (wires is null || wires.Length == 0) return JsonSerializer.Serialize(new BatchResult(0, 0, Array.Empty<WireResult>()));
+
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "No active GH2 document";
+
+        var results = new WireResult[wires.Length];
+
+        RhinoApp.InvokeAndWait(() =>
+        {
+            for (int i = 0; i < wires.Length; i++)
+                results[i] = WireOne(doc, i, wires[i]);
+
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
+        });
+
+        int okCount = 0;
+        for (int i = 0; i < results.Length; i++) if (results[i].Ok) okCount++;
+
+        return JsonSerializer.Serialize(new BatchResult(wires.Length, okCount, results));
+    }
+
+    private static WireResult WireOne(Document doc, int idx, WireSpec w)
+    {
+        if (!Guid.TryParse(w.SrcId, out Guid srcGuid))
+            return new WireResult(idx, false, null, null, $"Invalid src_id '{w.SrcId}'");
+        if (!Guid.TryParse(w.DstId, out Guid dstGuid))
+            return new WireResult(idx, false, null, null, $"Invalid dst_id '{w.DstId}'");
+
+        var srcObj = doc.Objects.Find(srcGuid);
+        if (srcObj is null) return new WireResult(idx, false, null, null, $"Source '{srcGuid}' not found");
+        var dstObj = doc.Objects.Find(dstGuid);
+        if (dstObj is null) return new WireResult(idx, false, null, null, $"Destination '{dstGuid}' not found");
+
+        if (!GH2_GraphOps.TryResolveOutput(srcObj, w.Src, out IParameter? srcParam, out string srcErr))
+            return new WireResult(idx, false, null, null, srcErr);
+        if (!GH2_GraphOps.TryResolveInput(dstObj, w.Dst, out IParameter? dstParam, out string dstErr))
+            return new WireResult(idx, false, null, null, dstErr);
+
+        try
+        {
+            if (dstParam!.Inputs.IndexOf(srcParam!.InstanceId) < 0)
+                Connections.Connect(srcParam!, dstParam!);
+        }
+        catch (Exception ex)
+        {
+            return new WireResult(idx, false, null, null, ex.Message);
+        }
+
+        return new WireResult(
+            idx, true,
+            new Endpoint(srcObj.InstanceId, srcParam!.Nomen.Name),
+            new Endpoint(dstObj.InstanceId, dstParam!.Nomen.Name),
+            null);
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
@@ -27,14 +27,11 @@ public static class GH2_ConnectManyTool
 
         var results = new WireResult[wires.Length];
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            for (int i = 0; i < wires.Length; i++)
-                results[i] = WireOne(doc, i, wires[i]);
+        for (int i = 0; i < wires.Length; i++)
+            results[i] = WireOne(doc, i, wires[i]);
 
-            if (solve) doc.Solution.Start();
-            GH2_Utils.Redraw();
-        });
+        if (solve) doc.Solution.Start();
+        GH2_Utils.Redraw();
 
         int okCount = 0;
         for (int i = 0; i < results.Length; i++) if (results[i].Ok) okCount++;

--- a/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
@@ -16,13 +16,13 @@ public static class GH2_ConnectManyTool
     [McpServerTool(Name = "g2_connect_many")]
     [Description("Wire multiple output→input connections in one call on the active GH2 canvas. Same selector semantics as 'g2_connect'. A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
     public static string ConnectMany(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Array of {SrcId, Src, DstId, Dst} wire descriptors.")] WireSpec[] wires,
         [Description("If true, trigger a new solution after wiring. Set false to batch further.")] bool solve = true)
     {
         if (wires is null || wires.Length == 0) return JsonSerializer.Serialize(new BatchResult(0, 0, Array.Empty<WireResult>()));
 
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "No active GH2 document";
 
         var results = new WireResult[wires.Length];

--- a/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectManyTool.cs
@@ -13,8 +13,8 @@ public static class GH2_ConnectManyTool
     public record struct WireResult(int Index, bool Ok, Endpoint? Src, Endpoint? Dst, string? Error);
     public record struct BatchResult(int Count, int OkCount, WireResult[] Wires);
 
-    [McpServerTool(Name = "connect_many")]
-    [Description("Wire multiple output→input connections in one call on the active GH2 canvas. Same selector semantics as 'connect'. A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
+    [McpServerTool(Name = "g2_connect_many")]
+    [Description("Wire multiple output→input connections in one call on the active GH2 canvas. Same selector semantics as 'g2_connect'. A failed wire does not stop later ones; per-wire results are returned. solve runs once at the end.")]
     public static string ConnectMany(
         RhinoDoc _,
         [Description("Array of {SrcId, Src, DstId, Dst} wire descriptors.")] WireSpec[] wires,

--- a/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
@@ -1,0 +1,70 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Doc;
+using Grasshopper2.Parameters;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_ConnectTool
+{
+    public record struct Endpoint(Guid Id, string Param);
+    public record struct OkResult(bool Ok, Endpoint Src, Endpoint Dst);
+    public record struct ErrResult(bool Ok, string Error);
+
+    [McpServerTool(Name = "connect")]
+    [Description("Wire an output parameter to an input parameter on the active GH2 canvas. 'src' and 'dst' may be a numeric index or a Name/UserName. For pure params (e.g. a slider) pass '' or '0'.")]
+    public static string Connect(
+        RhinoDoc _,
+        [Description("Guid of the source IDocumentObject.")] string src_id,
+        [Description("Output identifier: numeric index, output Name, or UserName. Use '' or '0' for pure params.")] string src,
+        [Description("Guid of the destination IDocumentObject.")] string dst_id,
+        [Description("Input identifier: numeric index, input Name, or UserName. Use '' or '0' for pure params.")] string dst,
+        [Description("If true, trigger a new solution after wiring. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
+    {
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return Err("No active GH2 document");
+
+        if (!Guid.TryParse(src_id, out Guid srcGuid)) return Err($"Invalid src_id guid '{src_id}'");
+        if (!Guid.TryParse(dst_id, out Guid dstGuid)) return Err($"Invalid dst_id guid '{dst_id}'");
+
+        var srcObj = doc.Objects.Find(srcGuid);
+        if (srcObj is null) return Err($"Source object '{srcGuid}' not found");
+        var dstObj = doc.Objects.Find(dstGuid);
+        if (dstObj is null) return Err($"Destination object '{dstGuid}' not found");
+
+        if (!GH2_GraphOps.TryResolveOutput(srcObj, src, out IParameter? srcParam, out string srcErr))
+            return Err(srcErr);
+        if (!GH2_GraphOps.TryResolveInput(dstObj, dst, out IParameter? dstParam, out string dstErr))
+            return Err(dstErr);
+
+        if (dstParam!.Inputs.IndexOf(srcParam!.InstanceId) >= 0)
+        {
+            return JsonSerializer.Serialize(new OkResult(
+                true,
+                new Endpoint(srcObj.InstanceId, srcParam!.Nomen.Name),
+                new Endpoint(dstObj.InstanceId, dstParam!.Nomen.Name)));
+        }
+
+        try
+        {
+            RhinoApp.InvokeAndWait(() =>
+            {
+                Connections.Connect(srcParam!, dstParam!);
+                if (solve) doc.Solution.Start();
+                GH2_Utils.Redraw();
+            });
+        }
+        catch (Exception ex)
+        {
+            return Err(ex.Message);
+        }
+
+        return JsonSerializer.Serialize(new OkResult(
+            true,
+            new Endpoint(srcObj.InstanceId, srcParam!.Nomen.Name),
+            new Endpoint(dstObj.InstanceId, dstParam!.Nomen.Name)));
+    }
+
+    private static string Err(string msg) => JsonSerializer.Serialize(new ErrResult(false, msg));
+}

--- a/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
@@ -48,12 +48,9 @@ public static class GH2_ConnectTool
 
         try
         {
-            RhinoApp.InvokeAndWait(() =>
-            {
-                Connections.Connect(srcParam!, dstParam!);
-                if (solve) doc.Solution.Start();
-                GH2_Utils.Redraw();
-            });
+            Connections.Connect(srcParam!, dstParam!);
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
         }
         catch (Exception ex)
         {

--- a/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
@@ -15,14 +15,14 @@ public static class GH2_ConnectTool
     [McpServerTool(Name = "g2_connect")]
     [Description("Wire an output parameter to an input parameter on the active GH2 canvas. 'src' and 'dst' may be a numeric index or a Name/UserName. For pure params (e.g. a slider) pass '' or '0'.")]
     public static string Connect(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Guid of the source IDocumentObject.")] string src_id,
         [Description("Output identifier: numeric index, output Name, or UserName. Use '' or '0' for pure params.")] string src,
         [Description("Guid of the destination IDocumentObject.")] string dst_id,
         [Description("Input identifier: numeric index, input Name, or UserName. Use '' or '0' for pure params.")] string dst,
         [Description("If true, trigger a new solution after wiring. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
     {
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return Err("No active GH2 document");
 
         if (!Guid.TryParse(src_id, out Guid srcGuid)) return Err($"Invalid src_id guid '{src_id}'");

--- a/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_ConnectTool.cs
@@ -12,7 +12,7 @@ public static class GH2_ConnectTool
     public record struct OkResult(bool Ok, Endpoint Src, Endpoint Dst);
     public record struct ErrResult(bool Ok, string Error);
 
-    [McpServerTool(Name = "connect")]
+    [McpServerTool(Name = "g2_connect")]
     [Description("Wire an output parameter to an input parameter on the active GH2 canvas. 'src' and 'dst' may be a numeric index or a Name/UserName. For pure params (e.g. a slider) pass '' or '0'.")]
     public static string Connect(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
@@ -1,0 +1,85 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Components;
+using Grasshopper2.Doc;
+using Grasshopper2.Framework;
+using Grasshopper2.Parameters;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_DescribeComponentTool
+{
+    public record struct ParamInfo(string Name, string UserName, string Description, string TypeName, string Access, string Requirement);
+
+    public record struct ComponentInfo(
+        string Name,
+        string UserName,
+        string Description,
+        string Category,
+        string SubCategory,
+        string Kind,
+        ParamInfo[] Inputs,
+        ParamInfo[] Outputs);
+
+    [McpServerTool(Name = "describe_component")]
+    [Description("Look up a GH2 component by name and return its chapter, info, and input/output parameter list. Useful before placing or wiring components.")]
+    public static string Describe(
+        RhinoDoc _,
+        [Description("Component name as it appears in the component library (e.g. 'Slider', 'Addition'). Case-insensitive.")] string name)
+    {
+        ObjectProxy? proxy = null;
+        foreach (var p in ObjectProxies.Proxies)
+        {
+            if (string.Equals(p.Nomen.Name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                proxy = p;
+                break;
+            }
+        }
+        if (proxy is null) return $"No component named '{name}' found";
+
+        var obj = proxy.Emit();
+        if (obj is null) return $"Failed to instantiate '{name}'";
+
+        var inputs = Array.Empty<ParamInfo>();
+        var outputs = Array.Empty<ParamInfo>();
+        string kind;
+
+        switch (obj)
+        {
+            case Component comp:
+                kind = "Component";
+                inputs = comp.Parameters.Inputs.Select(ToInfo).ToArray();
+                outputs = comp.Parameters.Outputs.Select(ToInfo).ToArray();
+                break;
+            case IParameter param:
+                kind = "Param";
+                inputs = [ToInfo(param)];
+                break;
+            default:
+                kind = obj.GetType().Name;
+                break;
+        }
+
+        var info = new ComponentInfo(
+            obj.Nomen.Name,
+            obj.UserName ?? "",
+            obj.Nomen.Info,
+            obj.Nomen.Chapter,
+            obj.Nomen.Section,
+            kind,
+            inputs,
+            outputs);
+
+        return JsonSerializer.Serialize(info);
+    }
+
+    private static ParamInfo ToInfo(IParameter p) => new(
+        p.Nomen.Name,
+        p.UserName ?? "",
+        p.Nomen.Info,
+        p.TypeAssistantWeak?.Name ?? p.TypeAssistantWeak?.Type.Name ?? "",
+        p.Access.ToString(),
+        p.Requirement.ToString());
+}

--- a/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
@@ -1,9 +1,10 @@
 using RhMcp.Resources;
 
-using Grasshopper2.Components;
 using Grasshopper2.Doc;
 using Grasshopper2.Framework;
 using Grasshopper2.Parameters;
+
+using GH2Component = Grasshopper2.Components.Component;
 
 namespace RhMcp.Tools;
 
@@ -48,7 +49,7 @@ public static class GH2_DescribeComponentTool
 
         switch (obj)
         {
-            case Component comp:
+            case GH2Component comp:
                 kind = "Component";
                 inputs = comp.Parameters.Inputs.Select(ToInfo).ToArray();
                 outputs = comp.Parameters.Outputs.Select(ToInfo).ToArray();

--- a/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_DescribeComponentTool.cs
@@ -23,7 +23,7 @@ public static class GH2_DescribeComponentTool
         ParamInfo[] Inputs,
         ParamInfo[] Outputs);
 
-    [McpServerTool(Name = "describe_component")]
+    [McpServerTool(Name = "g2_describe_component")]
     [Description("Look up a GH2 component by name and return its chapter, info, and input/output parameter list. Useful before placing or wiring components.")]
     public static string Describe(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
@@ -1,0 +1,174 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Components;
+using Grasshopper2.Doc;
+using Grasshopper2.Parameters;
+using Grasshopper2.Parameters.Special;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_GetCanvasGraphTool
+{
+    public record struct MessageInfo(string Level, string Text);
+    public record struct Endpoint(Guid Id, string Param);
+    public record struct DataSummary(int Branches, int Items, string[] Sample);
+    public record struct DisplaySummary(int Count, string[] Sample);
+    public record struct InputInfo(string Name, string UserName, string TypeName, Endpoint[] Sources, DataSummary? Data);
+    public record struct OutputInfo(string Name, string UserName, string TypeName, DataSummary? Data, DisplaySummary? DisplaySummary);
+    public record struct ObjectInfo(
+        Guid Id,
+        string Name,
+        string Kind,
+        string Category,
+        string SubCategory,
+        float X,
+        float Y,
+        MessageInfo[] Messages,
+        InputInfo[] Inputs,
+        OutputInfo[] Outputs);
+    public record struct Wire(Endpoint From, Endpoint To);
+    public record struct Graph(ObjectInfo[] Objects, Wire[] Wires);
+
+    [McpServerTool(Name = "get_canvas_graph")]
+    [Description("Return a structured snapshot of the active GH2 canvas: objects (with messages, inputs/outputs and optional volatile data summaries) and wires between them.")]
+    public static string GetGraph(
+        RhinoDoc _,
+        [Description("Include per-param volatile data summaries (branches/items/sample).")] bool include_data = true,
+        [Description("How many items to include in each data sample.")] int sample_size = 3)
+    {
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "Could not get GH2 document";
+
+        var objects = new List<ObjectInfo>();
+        var wires = new List<Wire>();
+
+        foreach (var obj in doc.Objects.Forwards)
+        {
+            string kind = GH2_Utils.ClassifyKind(obj.GetType());
+
+            var messages = CollectMessages(obj);
+            var pivot = obj.Attributes?.Pivot ?? default;
+
+            InputInfo[] inputs;
+            OutputInfo[] outputs;
+
+            if (obj is Component comp)
+            {
+                inputs = comp.Parameters.Inputs.Select(p => MakeInput(doc, p, include_data, sample_size, wires, obj.InstanceId)).ToArray();
+                outputs = comp.Parameters.Outputs.Select(p => MakeOutput(p, include_data, sample_size, displaySource: null)).ToArray();
+            }
+            else if (obj is IParameter param)
+            {
+                inputs = Array.Empty<InputInfo>();
+                outputs = new[] { MakeOutput(param, include_data, sample_size, displaySource: obj) };
+            }
+            else
+            {
+                inputs = Array.Empty<InputInfo>();
+                outputs = Array.Empty<OutputInfo>();
+            }
+
+            objects.Add(new ObjectInfo(
+                obj.InstanceId,
+                obj.Nomen.Name,
+                kind,
+                obj.Nomen.Chapter,
+                obj.Nomen.Section,
+                pivot.X,
+                pivot.Y,
+                messages,
+                inputs,
+                outputs));
+        }
+
+        return JsonSerializer.Serialize(new Graph(objects.ToArray(), wires.ToArray()));
+    }
+
+    private static MessageInfo[] CollectMessages(IDocumentObject obj)
+    {
+        var state = obj.State;
+        var data = state?.Data;
+        if (data is null) return Array.Empty<MessageInfo>();
+        var messages = data.Messages;
+        if (messages is null || messages.Count == 0) return Array.Empty<MessageInfo>();
+
+        var list = new List<MessageInfo>(messages.Count);
+        for (int i = 0; i < messages.Count; i++)
+        {
+            var m = messages[i];
+            list.Add(new MessageInfo(m.Level.ToString(), m.Text));
+        }
+        return list.ToArray();
+    }
+
+    private static InputInfo MakeInput(Document doc, IParameter param, bool includeData, int sampleSize, List<Wire> wires, Guid ownerId)
+    {
+        var sources = new List<Endpoint>();
+        foreach (var srcId in param.Inputs.Forwards)
+        {
+            var srcParam = doc.Objects.FindParameter(srcId);
+            if (srcParam is null) continue;
+
+            // Resolve to the founding object so that the wire endpoint maps to a
+            // top-level canvas object rather than to a nested input parameter.
+            var top = srcParam.FoundingObject ?? srcParam;
+            var ep = new Endpoint(top.InstanceId, srcParam.Nomen.Name);
+            sources.Add(ep);
+            wires.Add(new Wire(ep, new Endpoint(ownerId, param.Nomen.Name)));
+        }
+
+        return new InputInfo(
+            param.Nomen.Name,
+            param.UserName ?? "",
+            param.TypeAssistantWeak?.Name ?? "",
+            sources.ToArray(),
+            includeData ? Summarize(param, sampleSize) : null);
+    }
+
+    private static OutputInfo MakeOutput(IParameter param, bool includeData, int sampleSize, IDocumentObject? displaySource) => new(
+        param.Nomen.Name,
+        param.UserName ?? "",
+        param.TypeAssistantWeak?.Name ?? "",
+        includeData ? Summarize(param, sampleSize) : null,
+        displaySource is null ? null : SummarizeDisplay(displaySource, sampleSize));
+
+    private static DisplaySummary? SummarizeDisplay(IDocumentObject obj, int sampleSize)
+    {
+        try
+        {
+            if (obj is NumberSliderObject slider)
+            {
+                var n = slider.InternalNumber;
+                return new DisplaySummary(1, new[] { n.FormatValue(n.Value) });
+            }
+        }
+        catch { }
+        return null;
+    }
+
+    private static DataSummary? Summarize(IParameter param, int sampleSize)
+    {
+        try
+        {
+            var data = param.State?.Data?.Tree();
+            if (data is null) return null;
+
+            int branches = data.PathCount;
+            int items = data.ItemCount;
+
+            var sample = new List<string>();
+            foreach (var item in data.NonNullItems)
+            {
+                if (sample.Count >= sampleSize) break;
+                sample.Add(item?.ToString() ?? "");
+            }
+
+            return new DataSummary(branches, items, sample.ToArray());
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
@@ -34,11 +34,11 @@ public static class GH2_GetCanvasGraphTool
     [McpServerTool(Name = "g2_get_canvas_graph")]
     [Description("Return a structured snapshot of the active GH2 canvas: objects (with messages, inputs/outputs and optional volatile data summaries) and wires between them.")]
     public static string GetGraph(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Include per-param volatile data summaries (branches/items/sample).")] bool include_data = true,
         [Description("How many items to include in each data sample.")] int sample_size = 3)
     {
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "Could not get GH2 document";
 
         var objects = new List<ObjectInfo>();

--- a/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
@@ -31,7 +31,7 @@ public static class GH2_GetCanvasGraphTool
     public record struct Wire(Endpoint From, Endpoint To);
     public record struct Graph(ObjectInfo[] Objects, Wire[] Wires);
 
-    [McpServerTool(Name = "get_canvas_graph")]
+    [McpServerTool(Name = "g2_get_canvas_graph")]
     [Description("Return a structured snapshot of the active GH2 canvas: objects (with messages, inputs/outputs and optional volatile data summaries) and wires between them.")]
     public static string GetGraph(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_GetCanvasGraphTool.cs
@@ -1,9 +1,10 @@
 using RhMcp.Resources;
 
-using Grasshopper2.Components;
 using Grasshopper2.Doc;
 using Grasshopper2.Parameters;
 using Grasshopper2.Parameters.Special;
+
+using GH2Component = Grasshopper2.Components.Component;
 
 namespace RhMcp.Tools;
 
@@ -53,7 +54,7 @@ public static class GH2_GetCanvasGraphTool
             InputInfo[] inputs;
             OutputInfo[] outputs;
 
-            if (obj is Component comp)
+            if (obj is GH2Component comp)
             {
                 inputs = comp.Parameters.Inputs.Select(p => MakeInput(doc, p, include_data, sample_size, wires, obj.InstanceId)).ToArray();
                 outputs = comp.Parameters.Outputs.Select(p => MakeOutput(p, include_data, sample_size, displaySource: null)).ToArray();

--- a/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
@@ -1,0 +1,76 @@
+using RhMcp.Resources;
+
+using Eto.Drawing;
+
+using Grasshopper2.Doc;
+using Grasshopper2.Framework;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_PlaceComponentTool
+{
+    public record struct PlacedInfo(Guid Id, string Name, string Category, string SubCategory, float X, float Y);
+    public record struct Candidate(Guid Guid, string Name, string Category, string SubCategory);
+    public record struct AmbiguousResult(string Error, Candidate[] Candidates);
+
+    [McpServerTool(Name = "place_component")]
+    [Description("Place a GH2 component onto the active canvas. 'selector' may be a Guid (proxy id) or a component name. If multiple components share the name, returns an ambiguity payload listing candidates.")]
+    public static string Place(
+        RhinoDoc _,
+        [Description("Component Guid (proxy id) or component Name (case-insensitive).")] string selector,
+        [Description("Canvas X position in pixels.")] float x = 100,
+        [Description("Canvas Y position in pixels.")] float y = 100,
+        [Description("If true, trigger a new solution after placing. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
+    {
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "Could not get or create GH2 document";
+
+        IDocumentObject? obj;
+
+        if (Guid.TryParse(selector, out Guid guid))
+        {
+            var proxy = ObjectProxies.FindById(guid);
+            if (proxy is null) return $"No component with guid '{guid}' found";
+            obj = proxy.Emit();
+            if (obj is null) return $"Failed to emit object for guid '{guid}'";
+        }
+        else
+        {
+            var matches = new List<ObjectProxy>();
+            foreach (var p in ObjectProxies.Proxies)
+            {
+                if (string.Equals(p.Nomen.Name, selector, StringComparison.OrdinalIgnoreCase))
+                    matches.Add(p);
+            }
+
+            if (matches.Count == 0) return $"No component named '{selector}' found";
+
+            if (matches.Count > 1)
+            {
+                var candidates = matches
+                    .Select(p => new Candidate(p.Id, p.Nomen.Name, p.Nomen.Chapter, p.Nomen.Section))
+                    .ToArray();
+                return JsonSerializer.Serialize(new AmbiguousResult("ambiguous", candidates));
+            }
+
+            obj = matches[0].Emit();
+            if (obj is null) return $"Failed to instantiate '{selector}'";
+        }
+
+        RhinoApp.InvokeAndWait(() =>
+        {
+            doc.Objects.Add(obj, new PointF(x, y));
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
+        });
+
+        return JsonSerializer.Serialize(new PlacedInfo(
+            obj.InstanceId,
+            obj.Nomen.Name,
+            obj.Nomen.Chapter,
+            obj.Nomen.Section,
+            x,
+            y));
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
@@ -17,13 +17,13 @@ public static class GH2_PlaceComponentTool
     [McpServerTool(Name = "g2_place_component")]
     [Description("Place a GH2 component onto the active canvas. 'selector' may be a Guid (proxy id) or a component name. If multiple components share the name, returns an ambiguity payload listing candidates.")]
     public static string Place(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Component Guid (proxy id) or component Name (case-insensitive).")] string selector,
         [Description("Canvas X position in pixels.")] float x = 100,
         [Description("Canvas Y position in pixels.")] float y = 100,
         [Description("If true, trigger a new solution after placing. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
     {
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "Could not get or create GH2 document";
 
         IDocumentObject? obj;

--- a/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
@@ -58,12 +58,9 @@ public static class GH2_PlaceComponentTool
             if (obj is null) return $"Failed to instantiate '{selector}'";
         }
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            doc.Objects.Add(obj, new PointF(x, y));
-            if (solve) doc.Solution.Start();
-            GH2_Utils.Redraw();
-        });
+        doc.Objects.Add(obj, new PointF(x, y));
+        if (solve) doc.Solution.Start();
+        GH2_Utils.Redraw();
 
         return JsonSerializer.Serialize(new PlacedInfo(
             obj.InstanceId,

--- a/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceComponentTool.cs
@@ -14,7 +14,7 @@ public static class GH2_PlaceComponentTool
     public record struct Candidate(Guid Guid, string Name, string Category, string SubCategory);
     public record struct AmbiguousResult(string Error, Candidate[] Candidates);
 
-    [McpServerTool(Name = "place_component")]
+    [McpServerTool(Name = "g2_place_component")]
     [Description("Place a GH2 component onto the active canvas. 'selector' may be a Guid (proxy id) or a component name. If multiple components share the name, returns an ambiguity payload listing candidates.")]
     public static string Place(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
@@ -1,0 +1,55 @@
+using RhMcp.Resources;
+
+using Eto.Drawing;
+
+using Grasshopper2.Doc;
+using Grasshopper2.Parameters.Special;
+using Grasshopper2.UI;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_PlaceSliderTool
+{
+    public record struct SliderInfo(Guid Id, double Min, double Value, double Max, int Decimals, float X, float Y);
+
+    [McpServerTool(Name = "place_slider")]
+    [Description("Place a Number Slider on the active GH2 canvas with the given range and current value.")]
+    public static string Place(
+        RhinoDoc _,
+        [Description("Minimum slider value.")] double min,
+        [Description("Initial slider value.")] double value,
+        [Description("Maximum slider value.")] double max,
+        [Description("Canvas X position in pixels.")] float x = 100,
+        [Description("Canvas Y position in pixels.")] float y = 100,
+        [Description("Number of decimal places (0 for integer behaviour). Range: 0..12.")] int decimals = 3,
+        [Description("Optional UserName for the slider.")] string? name = null,
+        [Description("If true, trigger a new solution after placing. Set false to batch multiple operations and solve once at the end.")] bool solve = true)
+    {
+        if (decimals < 0 || decimals > 12)
+            return $"Invalid decimals '{decimals}'. Valid range: 0..12.";
+
+        if (!GH2_Utils.TryGetDoc(out Document doc))
+            return "Could not get or create GH2 document";
+
+        var number = new UiNumber(decimals, (decimal)value, (decimal)min, (decimal)max);
+        var slider = new NumberSliderObject(name ?? "num", number);
+
+        RhinoApp.InvokeAndWait(() =>
+        {
+            doc.Objects.Add(slider, new PointF(x, y));
+            if (solve) doc.Solution.Start();
+            GH2_Utils.Redraw();
+        });
+
+        var current = slider.InternalNumber;
+        return JsonSerializer.Serialize(new SliderInfo(
+            slider.InstanceId,
+            (double)current.Lower,
+            (double)current.Value,
+            (double)current.Upper,
+            current.Decimals,
+            x,
+            y));
+    }
+}

--- a/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
@@ -35,12 +35,9 @@ public static class GH2_PlaceSliderTool
         var number = new UiNumber(decimals, (decimal)value, (decimal)min, (decimal)max);
         var slider = new NumberSliderObject(name ?? "num", number);
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            doc.Objects.Add(slider, new PointF(x, y));
-            if (solve) doc.Solution.Start();
-            GH2_Utils.Redraw();
-        });
+        doc.Objects.Add(slider, new PointF(x, y));
+        if (solve) doc.Solution.Start();
+        GH2_Utils.Redraw();
 
         var current = slider.InternalNumber;
         return JsonSerializer.Serialize(new SliderInfo(

--- a/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
@@ -16,7 +16,7 @@ public static class GH2_PlaceSliderTool
     [McpServerTool(Name = "g2_place_slider")]
     [Description("Place a Number Slider on the active GH2 canvas with the given range and current value.")]
     public static string Place(
-        RhinoDoc _,
+        RhinoDoc rhDoc,
         [Description("Minimum slider value.")] double min,
         [Description("Initial slider value.")] double value,
         [Description("Maximum slider value.")] double max,
@@ -29,7 +29,7 @@ public static class GH2_PlaceSliderTool
         if (decimals < 0 || decimals > 12)
             return $"Invalid decimals '{decimals}'. Valid range: 0..12.";
 
-        if (!GH2_Utils.TryGetDoc(out Document doc))
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document doc))
             return "Could not get or create GH2 document";
 
         var number = new UiNumber(decimals, (decimal)value, (decimal)min, (decimal)max);

--- a/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_PlaceSliderTool.cs
@@ -13,7 +13,7 @@ public static class GH2_PlaceSliderTool
 {
     public record struct SliderInfo(Guid Id, double Min, double Value, double Max, int Decimals, float X, float Y);
 
-    [McpServerTool(Name = "place_slider")]
+    [McpServerTool(Name = "g2_place_slider")]
     [Description("Place a Number Slider on the active GH2 canvas with the given range and current value.")]
     public static string Place(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_SearchComponentsTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SearchComponentsTool.cs
@@ -1,0 +1,49 @@
+using RhMcp.Resources;
+
+using Grasshopper2.Framework;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GH2_SearchComponentsTool
+{
+    public record struct ProxyHit(
+        Guid Guid,
+        string Name,
+        string Category,
+        string SubCategory,
+        string Kind,
+        string Description);
+
+    [McpServerTool(Name = "search_components")]
+    [Description("Search the GH2 component library by substring. Matches Name and Info (case-insensitive). Optional exact-match chapter/section filters. Returns up to 'limit' matches.")]
+    public static string Search(
+        RhinoDoc _,
+        [Description("Substring to match against component Name and Info. Case-insensitive.")] string query,
+        [Description("Optional exact-match chapter filter (e.g. 'Maths', 'Params').")] string? category = null,
+        [Description("Optional exact-match section filter (e.g. 'Operators').")] string? subcategory = null,
+        [Description("Maximum number of results to return.")] int limit = 20)
+    {
+        if (string.IsNullOrEmpty(query)) return "query is required";
+
+        var hits = new List<ProxyHit>();
+        foreach (var p in ObjectProxies.Proxies)
+        {
+            var n = p.Nomen;
+            if (category is not null && !string.Equals(n.Chapter, category, StringComparison.OrdinalIgnoreCase)) continue;
+            if (subcategory is not null && !string.Equals(n.Section, subcategory, StringComparison.OrdinalIgnoreCase)) continue;
+
+            if (!Match(n.Name, query) && !Match(n.Info, query)) continue;
+
+            string kind = GH2_Utils.ClassifyKind(p.Type);
+
+            hits.Add(new ProxyHit(p.Id, n.Name, n.Chapter, n.Section, kind, n.Info));
+            if (hits.Count >= limit) break;
+        }
+
+        return JsonSerializer.Serialize(hits);
+    }
+
+    private static bool Match(string? haystack, string needle) =>
+        haystack is not null && haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+}

--- a/rhino/plugin/Tools/GH2/GH2_SearchComponentsTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SearchComponentsTool.cs
@@ -15,7 +15,7 @@ public static class GH2_SearchComponentsTool
         string Kind,
         string Description);
 
-    [McpServerTool(Name = "search_components")]
+    [McpServerTool(Name = "g2_search_components")]
     [Description("Search the GH2 component library by substring. Matches Name and Info (case-insensitive). Optional exact-match chapter/section filters. Returns up to 'limit' matches.")]
     public static string Search(
         RhinoDoc _,

--- a/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
@@ -1,23 +1,60 @@
 using RhMcp.Resources;
 
-using Grasshopper2;
-using Grasshopper2.UI;
+using Grasshopper2.Doc;
 
 namespace RhMcp.Tools;
 
 [McpServerToolType]
 public static class GH2_SolveTool
 {
+    public record struct StatusInfo(string Name, MessageItem[] Messages);
+    public record struct MessageItem(string Level, string Text);
+
     [McpServerTool(Name = "solve_canvas")]
-    [Description("Solves the active GH2 canvas")]
+    [Description("Solves the active GH2 canvas. Returns per-object warning/error messages, if any.")]
     public static string SolveCanvas(RhinoDoc _)
     {
-        if (!GH2_Utils.TryGetDoc(out var ghDoc)) return "Could not get GHDoc";
+        if (!GH2_Utils.TryGetDoc(out Document ghDoc)) return "Could not get GH2 document";
 
-        var solution = ghDoc.Solution.StartWait();
+        try
+        {
+            RhinoApp.InvokeAndWait(() =>
+            {
+                ghDoc.Solution.StartWait();
+            });
+        }
+        catch (Exception ex)
+        {
+            return ex.Message;
+        }
 
-        // TODO : Return the solutoin as a nice JSON result
+        var statuses = CollectStatuses(ghDoc);
+        if (statuses.Count == 0) return "Success";
 
-        return JsonSerializer.Serialize(new { /* result */ });
+        return JsonSerializer.Serialize(new { errMsg = "Solution encountered some errors", statuses });
+    }
+
+    private static List<StatusInfo> CollectStatuses(Document ghDoc)
+    {
+        var statuses = new List<StatusInfo>();
+        foreach (var obj in ghDoc.Objects.ActiveObjects)
+        {
+            var data = obj.State?.Data;
+            if (data is null) continue;
+            var messages = data.Messages;
+            if (messages is null || messages.Count == 0) continue;
+
+            var items = new List<MessageItem>();
+            for (int i = 0; i < messages.Count; i++)
+            {
+                var m = messages[i];
+                if (m.Level == Grasshopper2.Doc.MessageLevel.Remark) continue;
+                items.Add(new MessageItem(m.Level.ToString(), m.Text));
+            }
+            if (items.Count == 0) continue;
+
+            statuses.Add(new StatusInfo(obj.Nomen.Name, items.ToArray()));
+        }
+        return statuses;
     }
 }

--- a/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
@@ -12,9 +12,9 @@ public static class GH2_SolveTool
 
     [McpServerTool(Name = "g2_solve_canvas")]
     [Description("Solves the active GH2 canvas. Returns per-object warning/error messages, if any.")]
-    public static string SolveCanvas(RhinoDoc _)
+    public static string SolveCanvas(RhinoDoc rhDoc)
     {
-        if (!GH2_Utils.TryGetDoc(out Document ghDoc)) return "Could not get GH2 document";
+        if (!GH2_Utils.TryGetDoc(rhDoc, out Document ghDoc)) return "Could not get GH2 document";
 
         try
         {

--- a/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
@@ -18,10 +18,7 @@ public static class GH2_SolveTool
 
         try
         {
-            RhinoApp.InvokeAndWait(() =>
-            {
-                ghDoc.Solution.StartWait();
-            });
+            ghDoc.Solution.StartWait();
         }
         catch (Exception ex)
         {

--- a/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_SolveTool.cs
@@ -10,7 +10,7 @@ public static class GH2_SolveTool
     public record struct StatusInfo(string Name, MessageItem[] Messages);
     public record struct MessageItem(string Level, string Text);
 
-    [McpServerTool(Name = "solve_canvas")]
+    [McpServerTool(Name = "g2_solve_canvas")]
     [Description("Solves the active GH2 canvas. Returns per-object warning/error messages, if any.")]
     public static string SolveCanvas(RhinoDoc _)
     {

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -16,7 +16,7 @@ public static class GH2_StartTool
         }
         catch (Exception ex)
         {
-            return $"start_gh2 threw: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}";
+            return $"g2_start threw: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}";
         }
     }
 

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -12,7 +12,7 @@ public static class GH2_StartTool
     [Description("Starts GH2")]
     public static string Launch(RhinoDoc _)
     {
-        if (!IsInstalled()) return "G2 is not installed";
+        if (RhinoApp.Version.Major < 9) return "G2 is not installed";
         try
         {
             RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_G2", true));
@@ -25,11 +25,5 @@ public static class GH2_StartTool
     }
 
     private static string Verify() => GH2_Utils.TryGetDoc(out _) ? "Opened G2" : "Failure opening G2";
-
-    private static bool IsInstalled()
-    {
-        var plugIn = Rhino.PlugIns.PlugIn.Find(GH2_PlugInId);
-        return plugIn is not null;
-    }
 
 }

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -10,13 +10,13 @@ public static class GH2_StartTool
 
     [McpServerTool(Name = "g2_start")]
     [Description("Starts GH2")]
-    public static string Launch(RhinoDoc _)
+    public static string Launch(RhinoDoc doc)
     {
         if (RhinoApp.Version.Major < 9) return "G2 is not installed";
         try
         {
             RhinoApp.RunScript(doc.RuntimeSerialNumber, "_G2", true);
-            return Verify();
+            return Verify(doc);
         }
         catch (Exception ex)
         {
@@ -24,6 +24,6 @@ public static class GH2_StartTool
         }
     }
 
-    private static string Verify() => GH2_Utils.TryGetDoc(out _) ? "Opened G2" : "Failure opening G2";
+    private static string Verify(RhinoDoc doc) => GH2_Utils.TryGetDoc(doc, out _) ? "Opened G2" : "Failure opening G2";
 
 }

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -15,7 +15,7 @@ public static class GH2_StartTool
         if (RhinoApp.Version.Major < 9) return "G2 is not installed";
         try
         {
-            RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_G2", true));
+            RhinoApp.RunScript("_G2", true);
             return Verify();
         }
         catch (Exception ex)

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -6,7 +6,7 @@ namespace RhMcp.Tools;
 public static class GH2_StartTool
 {
     
-    private static Guid GH2_PlugInId { get; }= new("8307876d-a461-4daa-bb77-eb3715925513");
+    private static Guid GH2_PlugInId { get; } = new("8307876d-a461-4daa-bb77-eb3715925513");
 
     [McpServerTool(Name = "g2_start")]
     [Description("Starts GH2")]
@@ -15,7 +15,7 @@ public static class GH2_StartTool
         if (RhinoApp.Version.Major < 9) return "G2 is not installed";
         try
         {
-            RhinoApp.RunScript("_G2", true);
+            RhinoApp.RunScript(doc.RuntimeSerialNumber, "_G2", true);
             return Verify();
         }
         catch (Exception ex)

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -5,19 +5,31 @@ namespace RhMcp.Tools;
 [McpServerToolType]
 public static class GH2_StartTool
 {
+    
+    private static Guid GH2_PlugInId { get; }= new("8307876d-a461-4daa-bb77-eb3715925513");
+
     [McpServerTool(Name = "g2_start")]
     [Description("Starts GH2")]
     public static string Launch(RhinoDoc _)
     {
-        if (!GH2_Utils.IsInstalled()) return "G2 is not installed";
+        if (!IsInstalled()) return "G2 is not installed";
         try
         {
-            return GH2_Utils.TryGetDoc(out var __) ? "Opened G2" : "Failure opening G2";
+            RhinoApp.InvokeAndWait(() => RhinoApp.RunScript("_G2", true));
+            return Verify();
         }
         catch (Exception ex)
         {
             return $"g2_start threw: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}";
         }
+    }
+
+    private static string Verify() => GH2_Utils.TryGetDoc(out _) ? "Opened G2" : "Failure opening G2";
+
+    private static bool IsInstalled()
+    {
+        var plugIn = Rhino.PlugIns.PlugIn.Find(GH2_PlugInId);
+        return plugIn is not null;
     }
 
 }

--- a/rhino/plugin/Tools/GH2/GH2_StartTool.cs
+++ b/rhino/plugin/Tools/GH2/GH2_StartTool.cs
@@ -5,7 +5,7 @@ namespace RhMcp.Tools;
 [McpServerToolType]
 public static class GH2_StartTool
 {
-    [McpServerTool(Name = "start_gh2")]
+    [McpServerTool(Name = "g2_start")]
     [Description("Starts GH2")]
     public static string Launch(RhinoDoc _)
     {

--- a/rhino/plugin/Tools/GetCommandsTool.cs
+++ b/rhino/plugin/Tools/GetCommandsTool.cs
@@ -10,6 +10,7 @@ public static class GetCommandsTool
     [McpServerTool(Name = "get_commands")]
     [Description("Discover Rhino command names available to run_command. Returns English names from all registered plugins (including those not yet loaded; invoking such a command may trigger plugin load). Test commands are excluded. Use filter to narrow the list before calling run_command.")]
     public static string GetCommands(
+        RhinoDoc doc,
         [Description("Substring filter (case-insensitive). Strongly recommended — unfiltered results can exceed 1000 commands.")] string? filter = null)
     {
         string[] all = Command.GetCommandNames(true, false)

--- a/rhino/plugin/Tools/GetViewportImageTool.cs
+++ b/rhino/plugin/Tools/GetViewportImageTool.cs
@@ -40,73 +40,66 @@ public static class GetViewportImageTool
         string? error = null;
         CaptureMetadata? meta = null;
 
-        RhinoApp.InvokeAndWait(() =>
+        var vp = activeView.ActiveViewport;
+
+        try
         {
-            var vp = activeView.ActiveViewport;
-
-            try
+            if (!string.IsNullOrEmpty(view))
             {
-                if (!string.IsNullOrEmpty(view))
+                var proj = ParseProjection(view);
+                if (proj == DefinedViewportProjection.None)
                 {
-                    var proj = ParseProjection(view);
-                    if (proj == DefinedViewportProjection.None)
-                    {
-                        error = $"Unknown view: {view}";
-                        return;
-                    }
-                    vp.SetProjection(proj, null, true);
+                    return [new TextContent(SerializeResult(meta, $"Unknown view: {view}"))];
                 }
-
-                if (!string.IsNullOrEmpty(displayMode))
-                {
-                    var mode = FindDisplayMode(displayMode);
-                    if (mode is null)
-                    {
-                        error = $"Unknown display mode: {displayMode}";
-                        return;
-                    }
-                    vp.DisplayMode = mode;
-                }
-
-                if (cameraLocation is not null)
-                    vp.SetCameraLocation((Point3d)cameraLocation, false);
-
-                if (target is not null)
-                    vp.SetCameraTarget((Point3d)target, false);
-
-                if (boxMin is not null && boxMax is not null)
-                {
-                    var bb = new BoundingBox((Point3d)boxMin, (Point3d)boxMax);
-                    if (bb.IsValid)
-                        vp.ZoomBoundingBox(bb);
-                    else
-                    {
-                        error = "boxMin/boxMax do not form a valid bounding box.";
-                        return;
-                    }
-                }
-
-                if (zoom.HasValue)
-                    vp.Magnify(zoom.Value, true);
-
-                activeView.Redraw();
-
-                meta = GatherMetadata(activeView, width, height);
-
-                if (meta.VisibleObjectCount == 0)
-                {
-                    error = "Viewport is empty — no document objects intersect the view frustum. " +
-                            "Camera/target may be off the model. See metadata.scene.boundingBox for where geometry actually lives.";
-                    return;
-                }
-
-                bitmap = activeView.CaptureToBitmap(new Size(width, height));
+                vp.SetProjection(proj, null, true);
             }
-            catch (Exception ex)
+
+            if (!string.IsNullOrEmpty(displayMode))
             {
-                error = $"Capture failed: {ex.Message}";
+                var mode = FindDisplayMode(displayMode);
+                if (mode is null)
+                {
+                    return [new TextContent(SerializeResult(meta, $"Unknown display mode: {displayMode}"))];
+                }
+                vp.DisplayMode = mode;
             }
-        });
+
+            if (cameraLocation is not null)
+                vp.SetCameraLocation((Point3d)cameraLocation, false);
+
+            if (target is not null)
+                vp.SetCameraTarget((Point3d)target, false);
+
+            if (boxMin is not null && boxMax is not null)
+            {
+                var bb = new BoundingBox((Point3d)boxMin, (Point3d)boxMax);
+                if (bb.IsValid)
+                    vp.ZoomBoundingBox(bb);
+                else
+                {
+                    return [new TextContent(SerializeResult(meta, "boxMin/boxMax do not form a valid bounding box."))];
+                }
+            }
+
+            if (zoom.HasValue)
+                vp.Magnify(zoom.Value, true);
+
+            activeView.Redraw();
+
+            meta = GatherMetadata(activeView, width, height);
+
+            if (meta.VisibleObjectCount == 0)
+            {
+                return [new TextContent(SerializeResult(meta, "Viewport is empty — no document objects intersect the view frustum. " +
+                        "Camera/target may be off the model. See metadata.scene.boundingBox for where geometry actually lives."))];
+            }
+
+            bitmap = activeView.CaptureToBitmap(new Size(width, height));
+        }
+        catch (Exception ex)
+        {
+            error = $"Capture failed: {ex.Message}";
+        }
 
         if (error is not null)
         {

--- a/rhino/plugin/Tools/OpenDocTool.cs
+++ b/rhino/plugin/Tools/OpenDocTool.cs
@@ -1,0 +1,41 @@
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class OpenDocTool
+{
+    [McpServerTool(Name = "open_doc")]
+    [Description("Import a .3dm (or other supported) file into the current document. Headless — no dialogs. Optionally clear the document first to make this behave like an open-in-place.")]
+    public static string OpenDoc(
+        RhinoDoc doc,
+        [Description("Absolute path to the file to import")] string path,
+        [Description("If true, delete all objects in the current document before importing")] bool clearFirst = false)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("path is required.", nameof(path));
+
+        if (!System.IO.File.Exists(path))
+            throw new System.IO.FileNotFoundException($"File not found: {path}", path);
+
+        int cleared = 0;
+        if (clearFirst)
+        {
+            var ids = doc.Objects.Select(o => o.Id).ToList();
+            foreach (var id in ids)
+                if (doc.Objects.Delete(id, true)) cleared++;
+        }
+
+        var before = doc.Objects.Count;
+        if (!doc.Import(path))
+            throw new InvalidOperationException($"Failed to import: {path}");
+        var imported = doc.Objects.Count - before;
+
+        doc.Views.Redraw();
+
+        return JsonSerializer.Serialize(new
+        {
+            path,
+            imported,
+            cleared,
+        });
+    }
+}

--- a/rhino/plugin/Tools/RunCSharpTool.cs
+++ b/rhino/plugin/Tools/RunCSharpTool.cs
@@ -14,7 +14,7 @@ public static class RunCSharpTool
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.cs");
         File.WriteAllText(tmp, script);
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.InvokeAndWait(() => RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false));
+        RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false);
         string[] lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         _ = Task.Delay(15_000).ContinueWith(_ => { try { File.Delete(tmp); } catch { } });

--- a/rhino/plugin/Tools/RunCSharpTool.cs
+++ b/rhino/plugin/Tools/RunCSharpTool.cs
@@ -9,6 +9,7 @@ public static class RunCSharpTool
     [McpServerTool(Name = "run_csharp")]
     [Description("Execute a C# script. Returns JSON with stdout and error fields; error is null on success.")]
     public static string RunCSharp(
+        RhinoDoc doc,
         [Description("Script")] string script)
     {
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.cs");

--- a/rhino/plugin/Tools/RunCSharpTool.cs
+++ b/rhino/plugin/Tools/RunCSharpTool.cs
@@ -7,7 +7,7 @@ namespace RhMcp.Tools;
 public static class RunCSharpTool
 {
     [McpServerTool(Name = "run_csharp")]
-    [Description("Execute a C# script. Returns JSON with stdout and error fields; error is null on success.")]
+    [Description("Execute a C# script targeted at this slot's document. The script editor injects `__rhino_doc__` (type `RhinoDoc`) — use it as your document handle instead of `RhinoDoc.ActiveDoc` or anything else. Returns JSON with stdout and error fields; error is null on success.")]
     public static string RunCSharp(
         RhinoDoc doc,
         [Description("Script")] string script)

--- a/rhino/plugin/Tools/RunCSharpTool.cs
+++ b/rhino/plugin/Tools/RunCSharpTool.cs
@@ -14,7 +14,7 @@ public static class RunCSharpTool
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.cs");
         File.WriteAllText(tmp, script);
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false);
+        RhinoApp.RunScript(doc.RuntimeSerialNumber, $"-ScriptEditor _Run \"{tmp}\"", false);
         string[] lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         _ = Task.Delay(15_000).ContinueWith(_ => { try { File.Delete(tmp); } catch { } });

--- a/rhino/plugin/Tools/RunCommandTool.cs
+++ b/rhino/plugin/Tools/RunCommandTool.cs
@@ -9,7 +9,7 @@ public static class RunCommandTool
         [Description("Rhino command string to execute")] string command)
     {
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.InvokeAndWait(() => RhinoApp.RunScript(command, false));
+        RhinoApp.RunScript(command, false);
         var lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         return lines is { Length: > 0 } ? string.Join("\n", lines) : "Done.";

--- a/rhino/plugin/Tools/RunCommandTool.cs
+++ b/rhino/plugin/Tools/RunCommandTool.cs
@@ -6,6 +6,7 @@ public static class RunCommandTool
     [McpServerTool(Name = "run_command")]
     [Description("Execute any Rhino command string and return command window output. Example: \"_Box 0,0,0 10,10,10\"")]
     public static string RunCommand(
+        RhinoDoc doc,
         [Description("Rhino command string to execute")] string command)
     {
         RhinoApp.CommandWindowCaptureEnabled = true;

--- a/rhino/plugin/Tools/RunCommandTool.cs
+++ b/rhino/plugin/Tools/RunCommandTool.cs
@@ -9,7 +9,7 @@ public static class RunCommandTool
         [Description("Rhino command string to execute")] string command)
     {
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.RunScript(command, false);
+        RhinoApp.RunScript(doc.RuntimeSerialNumber, command, false);
         var lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         return lines is { Length: > 0 } ? string.Join("\n", lines) : "Done.";

--- a/rhino/plugin/Tools/RunPythonTool.cs
+++ b/rhino/plugin/Tools/RunPythonTool.cs
@@ -9,6 +9,7 @@ public static class RunPythonTool
     [McpServerTool(Name = "run_python")]
     [Description("Execute a Python 3 script. Returns JSON with stdout and error fields; error is null on success.")]
     public static string RunPython(
+        RhinoDoc doc,
         [Description("Script")] string script)
     {
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.py");

--- a/rhino/plugin/Tools/RunPythonTool.cs
+++ b/rhino/plugin/Tools/RunPythonTool.cs
@@ -14,7 +14,7 @@ public static class RunPythonTool
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.py");
         File.WriteAllText(tmp, script);
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.InvokeAndWait(() => RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false));
+        RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false);
         string[] lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         _ = Task.Delay(15_000).ContinueWith(_ => { try { File.Delete(tmp); } catch { } });

--- a/rhino/plugin/Tools/RunPythonTool.cs
+++ b/rhino/plugin/Tools/RunPythonTool.cs
@@ -14,7 +14,7 @@ public static class RunPythonTool
         var tmp = Path.Combine(Path.GetTempPath(), $"rhino_mcp_{Guid.NewGuid():N}.py");
         File.WriteAllText(tmp, script);
         RhinoApp.CommandWindowCaptureEnabled = true;
-        RhinoApp.RunScript($"-ScriptEditor _Run \"{tmp}\"", false);
+        RhinoApp.RunScript(doc.RuntimeSerialNumber, $"-ScriptEditor _Run \"{tmp}\"", false);
         string[] lines = RhinoApp.CapturedCommandWindowStrings(true);
         RhinoApp.CommandWindowCaptureEnabled = false;
         _ = Task.Delay(15_000).ContinueWith(_ => { try { File.Delete(tmp); } catch { } });

--- a/rhino/plugin/Tools/RunPythonTool.cs
+++ b/rhino/plugin/Tools/RunPythonTool.cs
@@ -7,7 +7,7 @@ namespace RhMcp.Tools;
 public static class RunPythonTool
 {
     [McpServerTool(Name = "run_python")]
-    [Description("Execute a Python 3 script. Returns JSON with stdout and error fields; error is null on success.")]
+    [Description("Execute a Python 3 script targeted at this slot's document. The script editor injects `__rhino_doc__` — use it as your document handle. Do NOT trust `scriptcontext.doc` or `rhinoscriptsyntax` calls. Returns JSON with stdout and error fields; error is null on success.")]
     public static string RunPython(
         RhinoDoc doc,
         [Description("Script")] string script)

--- a/rhino/plugin/Tools/SaveDocTool.cs
+++ b/rhino/plugin/Tools/SaveDocTool.cs
@@ -18,11 +18,12 @@ public static class SaveDocTool
         if (!string.IsNullOrEmpty(dir) && !System.IO.Directory.Exists(dir))
             throw new System.IO.DirectoryNotFoundException($"Directory does not exist: {dir}");
 
+        // UpdateDocumentPath=false: avoids the post-write LockDocument that pops a modal in R9.
         var options = new FileWriteOptions
         {
             SuppressDialogBoxes = true,
             WriteUserData = true,
-            UpdateDocumentPath = true,
+            UpdateDocumentPath = false,
         };
 
         if (!doc.WriteFile(path, options))

--- a/rhino/plugin/Tools/SaveDocTool.cs
+++ b/rhino/plugin/Tools/SaveDocTool.cs
@@ -1,0 +1,37 @@
+using Rhino.FileIO;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class SaveDocTool
+{
+    [McpServerTool(Name = "save_doc")]
+    [Description("Write the current document to the given .3dm path. Headless — no dialogs. Overwrites any existing file at the path.")]
+    public static string SaveDoc(
+        RhinoDoc doc,
+        [Description("Absolute path to write the .3dm file to")] string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            throw new ArgumentException("path is required.", nameof(path));
+
+        var dir = System.IO.Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(dir) && !System.IO.Directory.Exists(dir))
+            throw new System.IO.DirectoryNotFoundException($"Directory does not exist: {dir}");
+
+        var options = new FileWriteOptions
+        {
+            SuppressDialogBoxes = true,
+            WriteUserData = true,
+            UpdateDocumentPath = true,
+        };
+
+        if (!doc.WriteFile(path, options))
+            throw new InvalidOperationException($"Failed to save: {path}");
+
+        return JsonSerializer.Serialize(new
+        {
+            path,
+            objects = doc.Objects.Count,
+        });
+    }
+}

--- a/rhino/plugin/Tools/SetCameraTool.cs
+++ b/rhino/plugin/Tools/SetCameraTool.cs
@@ -20,52 +20,41 @@ public static class SetCameraTool
         var view = doc.Views.ActiveView
             ?? throw new InvalidOperationException("No active view.");
 
-        string? error = null;
+        var vp = view.ActiveViewport;
 
-        RhinoApp.InvokeAndWait(() =>
+        if (!string.IsNullOrEmpty(projection))
         {
-            var vp = view.ActiveViewport;
+            if (projection.Equals("parallel", StringComparison.OrdinalIgnoreCase))
+                vp.ChangeToParallelProjection(true);
+            else if (projection.Equals("perspective", StringComparison.OrdinalIgnoreCase))
+                vp.ChangeToPerspectiveProjection(true, vp.Camera35mmLensLength > 0 ? vp.Camera35mmLensLength : 50.0);
+            else
+                return $"Unknown projection: {projection}";
+        }
 
-            if (!string.IsNullOrEmpty(projection))
-            {
-                if (projection.Equals("parallel", StringComparison.OrdinalIgnoreCase))
-                    vp.ChangeToParallelProjection(true);
-                else if (projection.Equals("perspective", StringComparison.OrdinalIgnoreCase))
-                    vp.ChangeToPerspectiveProjection(true, vp.Camera35mmLensLength > 0 ? vp.Camera35mmLensLength : 50.0);
-                else
-                {
-                    error = $"Unknown projection: {projection}";
-                    return;
-                }
-            }
+        if (location is not null)
+            vp.SetCameraLocation((Point3d)location, false);
 
-            if (location is not null)
-                vp.SetCameraLocation((Point3d)location, false);
+        if (target is not null)
+            vp.SetCameraTarget((Point3d)target, false);
 
-            if (target is not null)
-                vp.SetCameraTarget((Point3d)target, false);
+        if (up is not null)
+            vp.CameraUp = (Vector3d)up;
 
-            if (up is not null)
-                vp.CameraUp = (Vector3d)up;
+        if (lensLength.HasValue)
+            vp.Camera35mmLensLength = lensLength.Value;
 
-            if (lensLength.HasValue)
-                vp.Camera35mmLensLength = lensLength.Value;
+        if (boxMin is not null && boxMax is not null)
+        {
+            var bb = new BoundingBox((Point3d)boxMin, (Point3d)boxMax);
+            if (bb.IsValid)
+                vp.ZoomBoundingBox(bb);
+            else
+                return "boxMin/boxMax do not form a valid bounding box.";
+        }
 
-            if (boxMin is not null && boxMax is not null)
-            {
-                var bb = new BoundingBox((Point3d)boxMin, (Point3d)boxMax);
-                if (bb.IsValid)
-                    vp.ZoomBoundingBox(bb);
-                else
-                {
-                    error = "boxMin/boxMax do not form a valid bounding box.";
-                    return;
-                }
-            }
+        view.Redraw();
 
-            view.Redraw();
-        });
-
-        return error ?? "Camera updated.";
+        return "Camera updated.";
     }
 }

--- a/rhino/plugin/Tools/SetLayerMaterialTool.cs
+++ b/rhino/plugin/Tools/SetLayerMaterialTool.cs
@@ -25,36 +25,29 @@ public static class SetLayerMaterialTool
         if (color is not null && parsedColor is null)
             return $"Could not parse color: {color}";
 
-        string result = string.Empty;
+        var lay = doc.Layers[idx];
 
-        RhinoApp.InvokeAndWait(() =>
+        if (parsedColor.HasValue && applyToLayerColor)
+            lay.Color = parsedColor.Value;
+
+        var matIdx = lay.RenderMaterialIndex;
+        if (matIdx < 0)
         {
-            var lay = doc.Layers[idx];
+            var newMat = new Material { Name = $"{lay.Name}_material" };
+            if (parsedColor.HasValue) newMat.DiffuseColor = parsedColor.Value;
+            matIdx = doc.Materials.Add(newMat);
+            lay.RenderMaterialIndex = matIdx;
+        }
 
-            if (parsedColor.HasValue && applyToLayerColor)
-                lay.Color = parsedColor.Value;
+        var mat = doc.Materials[matIdx];
 
-            var matIdx = lay.RenderMaterialIndex;
-            if (matIdx < 0)
-            {
-                var newMat = new Material { Name = $"{lay.Name}_material" };
-                if (parsedColor.HasValue) newMat.DiffuseColor = parsedColor.Value;
-                matIdx = doc.Materials.Add(newMat);
-                lay.RenderMaterialIndex = matIdx;
-            }
+        if (parsedColor.HasValue) mat.DiffuseColor = parsedColor.Value;
+        if (transparency.HasValue) mat.Transparency = Math.Clamp(transparency.Value, 0.0, 1.0);
+        if (gloss.HasValue) mat.Shine = Math.Clamp(gloss.Value, 0.0, 1.0) * Material.MaxShine;
 
-            var mat = doc.Materials[matIdx];
-
-            if (parsedColor.HasValue) mat.DiffuseColor = parsedColor.Value;
-            if (transparency.HasValue) mat.Transparency = Math.Clamp(transparency.Value, 0.0, 1.0);
-            if (gloss.HasValue) mat.Shine = Math.Clamp(gloss.Value, 0.0, 1.0) * Material.MaxShine;
-
-            mat.CommitChanges();
-            doc.Views.Redraw();
-            result = $"Updated layer \"{layer}\" (material index {matIdx}).";
-        });
-
-        return result;
+        mat.CommitChanges();
+        doc.Views.Redraw();
+        return $"Updated layer \"{layer}\" (material index {matIdx}).";
     }
 
     private static Color? ParseColor(string? s)

--- a/rhino/plugin/Tools/SetSelectionTool.cs
+++ b/rhino/plugin/Tools/SetSelectionTool.cs
@@ -20,58 +20,55 @@ public static class SetSelectionTool
         var selected = 0;
         string? warning = null;
 
-        RhinoApp.InvokeAndWait(() =>
+        doc.Objects.UnselectAll();
+
+        var guidSet = new HashSet<Guid>();
+        foreach (var idStr in ids)
+            if (Guid.TryParse(idStr, out var g))
+                guidSet.Add(g);
+
+        foreach (var guid in guidSet)
         {
-            doc.Objects.UnselectAll();
+            var obj = doc.Objects.FindId(guid);
+            if (obj != null) { obj.Select(true); selected++; }
+        }
 
-            var guidSet = new HashSet<Guid>();
-            foreach (var idStr in ids)
-                if (Guid.TryParse(idStr, out var g))
-                    guidSet.Add(g);
-
-            foreach (var guid in guidSet)
+        if (names.Length > 0 || !string.IsNullOrEmpty(layer) || !string.IsNullOrEmpty(geometryType))
+        {
+            var settings = new ObjectEnumeratorSettings
             {
-                var obj = doc.Objects.FindId(guid);
-                if (obj != null) { obj.Select(true); selected++; }
+                ActiveObjects = true,
+                HiddenObjects = false,
+                LockedObjects = true,
+                DeletedObjects = false,
+                IncludeLights = true,
+                IncludeGrips = false,
+            };
+
+            if (!string.IsNullOrEmpty(geometryType))
+                settings.ObjectTypeFilter = ParseObjectType(geometryType);
+
+            if (!string.IsNullOrEmpty(layer))
+            {
+                var idx = doc.Layers.FindByFullPath(layer, RhinoMath.UnsetIntIndex);
+                if (idx >= 0)
+                    settings.LayerIndexFilter = idx;
+                else
+                    warning = $"Layer not found: {layer}";
             }
 
-            if (names.Length > 0 || !string.IsNullOrEmpty(layer) || !string.IsNullOrEmpty(geometryType))
+            var nameSet = names.ToHashSet(StringComparer.Ordinal);
+
+            foreach (var obj in doc.Objects.GetObjectList(settings))
             {
-                var settings = new ObjectEnumeratorSettings
-                {
-                    ActiveObjects = true,
-                    HiddenObjects = false,
-                    LockedObjects = true,
-                    DeletedObjects = false,
-                    IncludeLights = true,
-                    IncludeGrips = false,
-                };
-
-                if (!string.IsNullOrEmpty(geometryType))
-                    settings.ObjectTypeFilter = ParseObjectType(geometryType);
-
-                if (!string.IsNullOrEmpty(layer))
-                {
-                    var idx = doc.Layers.FindByFullPath(layer, RhinoMath.UnsetIntIndex);
-                    if (idx >= 0)
-                        settings.LayerIndexFilter = idx;
-                    else
-                        warning = $"Layer not found: {layer}";
-                }
-
-                var nameSet = names.ToHashSet(StringComparer.Ordinal);
-
-                foreach (var obj in doc.Objects.GetObjectList(settings))
-                {
-                    if (nameSet.Count > 0 && !nameSet.Contains(obj.Name ?? string.Empty)) continue;
-                    if (guidSet.Contains(obj.Id)) continue;
-                    obj.Select(true);
-                    selected++;
-                }
+                if (nameSet.Count > 0 && !nameSet.Contains(obj.Name ?? string.Empty)) continue;
+                if (guidSet.Contains(obj.Id)) continue;
+                obj.Select(true);
+                selected++;
             }
+        }
 
-            doc.Views.Redraw();
-        });
+        doc.Views.Redraw();
 
         return warning is null
             ? $"Selected {selected} object(s)."

--- a/rhino/plugin/Tools/ZoomToLayerTool.cs
+++ b/rhino/plugin/Tools/ZoomToLayerTool.cs
@@ -45,11 +45,8 @@ public static class ZoomToLayerTool
         var vp = doc.Views.ActiveView?.ActiveViewport
             ?? throw new InvalidOperationException("No active viewport.");
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            vp.ZoomBoundingBox(bb);
-            doc.Views.Redraw();
-        });
+        vp.ZoomBoundingBox(bb);
+        doc.Views.Redraw();
 
         return $"Zoomed to {count} object(s) on layer \"{layer}\".";
     }

--- a/rhino/plugin/Tools/ZoomToObjectTool.cs
+++ b/rhino/plugin/Tools/ZoomToObjectTool.cs
@@ -27,11 +27,8 @@ public static class ZoomToObjectTool
         var vp = doc.Views.ActiveView?.ActiveViewport
             ?? throw new InvalidOperationException("No active viewport.");
 
-        RhinoApp.InvokeAndWait(() =>
-        {
-            vp.ZoomBoundingBox(bb);
-            doc.Views.Redraw();
-        });
+        vp.ZoomBoundingBox(bb);
+        doc.Views.Redraw();
 
         return $"Zoomed to {ids.Length} object(s).";
     }

--- a/rhino/plugin/manifest.yml
+++ b/rhino/plugin/manifest.yml
@@ -1,6 +1,6 @@
 ---
 name: Rhino-MCP-Platform
-version: 0.2.0
+version: 0.1.0
 authors:
 - Callum Sykes
 - Dan Cascaval

--- a/rhino/rhino.slnx
+++ b/rhino/rhino.slnx
@@ -1,10 +1,14 @@
 <Solution>
   <Folder Name="/plugin/">
-    <Project Path="/Users/sykes/gits/rh-mcp/rhino/plugin/RhMcp.csproj" />
+    <Project Path="plugin/RhMcp.csproj" />
   </Folder>
-  <Folder Name="/router/" />
-  <Folder Name="/router/codegen/">
-    <Project Path="/Users/sykes/gits/rh-mcp/rhino/router/codegen/Router.Codegen.csproj" />
+  <Folder Name="/router/">
+    <Project Path="router/Router.csproj" />
+    <Folder Name="/router/codegen/">
+      <Project Path="router/codegen/Router.Codegen.csproj" />
+    </Folder>
   </Folder>
-  <Project Path="/Users/sykes/gits/rh-mcp/rhino/router/Router.csproj" />
+  <Folder Name="/tests/">
+    <Project Path="../tests/router/Router.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/rhino/router/AnimalNames.cs
+++ b/rhino/router/AnimalNames.cs
@@ -1,36 +1,23 @@
 namespace RhMcp.Router;
 
 // Hand-picked list of memorable, short, distinct animal names for slot IDs.
-// Picked in order; once exhausted, falls back to numbered "slot-N".
+// Names are seeded into SlotStore's name_pool table on first router startup;
+// allocation happens inside the spawn transaction so concurrent routers can't
+// claim the same name. Pool order here defines first-seed idx; once persisted
+// in the DB it's the DB row that wins.
 public static class AnimalNames
 {
-    private static readonly string[] _pool =
+    public static string[] Pool { get; } =
     [
-        "armadillo", "axolotl",   "badger",   "capybara", "cheetah",
-        "echidna",   "falcon",    "fennec",   "gecko",    "ibex",
-        "kakapo",    "kinkajou",  "koala",    "lemur",    "magpie",
-        "manatee",   "marmot",    "narwhal",  "ocelot",   "okapi",
-        "otter",     "panda",     "pangolin", "platypus", "puffin",
-        "quokka",    "sifaka",    "tapir",    "tarsier",  "wombat"
+        "aardvark",  "armadillo", "axolotl",  "badger",   "bonobo",
+        "capybara",  "caracal",   "cheetah",  "coati",    "dingo",
+        "dugong",    "echidna",   "falcon",   "fennec",   "ferret",
+        "gecko",     "gibbon",    "hedgehog", "ibex",     "jerboa",
+        "kakapo",    "kinkajou",  "koala",    "lemur",    "llama",
+        "macaw",     "magpie",    "manatee",  "marmot",   "meerkat",
+        "mongoose",  "narwhal",   "numbat",   "ocelot",   "okapi",
+        "otter",     "panda",     "pangolin", "pika",     "platypus",
+        "puffin",    "quokka",    "quoll",    "raccoon",  "serval",
+        "sifaka",    "tapir",     "tarsier",  "vicuna",   "wombat"
     ];
-
-    private static int _index = 0;
-    private static readonly object _lock = new();
-
-    public static string Next()
-    {
-        lock (_lock)
-        {
-            if (_index < _pool.Length)
-            {
-                return _pool[_index++];
-            }
-            return $"slot-{++_index}";
-        }
-    }
-
-    public static void Reset()
-    {
-        lock (_lock) _index = 0;
-    }
 }

--- a/rhino/router/Program.cs
+++ b/rhino/router/Program.cs
@@ -33,7 +33,7 @@ jsonOptions.TypeInfoResolverChain.Insert(0, RouterJsonContext.Default);
 var mcpBuilder = builder.Services
     .AddMcpServer(o =>
     {
-        o.ServerInfo = new() { Name = "rhino-mcp-router", Version = "0.2.0" };
+        o.ServerInfo = new() { Name = "rhino-mcp-router", Version = "0.1.0" };
     })
     .WithStdioServerTransport();
 

--- a/rhino/router/Program.cs
+++ b/rhino/router/Program.cs
@@ -6,9 +6,9 @@ using Microsoft.Extensions.Logging;
 using RhMcp.Router;
 using RhMcp.Router.Tools.Generated;
 
-var config = RouterConfig.FromArgs(args);
+RouterConfig config = RouterConfig.FromArgs(args);
 
-var builder = Host.CreateApplicationBuilder(args);
+HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 
 // Stdio MCP servers must not log to stdout — that's the JSON-RPC channel.
 // Route all logging to stderr.
@@ -19,6 +19,7 @@ builder.Services.AddSingleton(config);
 builder.Services.AddSingleton<RhinoLocator>();
 builder.Services.AddSingleton<RhinoControlClient>();
 builder.Services.AddSingleton<RhinoCrashReportFinder>();
+builder.Services.AddSingleton<SlotStore>();
 builder.Services.AddSingleton<RhinoManager>();
 builder.Services.AddSingleton<ProxyDispatcher>();
 builder.Services.AddHttpClient();
@@ -32,7 +33,7 @@ jsonOptions.TypeInfoResolverChain.Insert(0, RouterJsonContext.Default);
 var mcpBuilder = builder.Services
     .AddMcpServer(o =>
     {
-        o.ServerInfo = new() { Name = "rhino-mcp-router", Version = "0.1.0" };
+        o.ServerInfo = new() { Name = "rhino-mcp-router", Version = "0.2.0" };
     })
     .WithStdioServerTransport();
 

--- a/rhino/router/ProxyDispatcher.cs
+++ b/rhino/router/ProxyDispatcher.cs
@@ -49,7 +49,7 @@ public class ProxyDispatcher(
                 // needs (GH2_* tools pin "WIP"). Short-circuit before forwarding —
                 // the plugin would otherwise return a generic "unknown tool" MCP
                 // error and the agent wouldn't know the cause was a version mismatch.
-                if (defaultVersionOverride is not null && child.Version != defaultVersionOverride)
+                if (defaultVersionOverride is not null && !IsVersionCompatible(child.Version, defaultVersionOverride))
                 {
                     return SerializePayload(new SpawnErrorPayload(
                         "wrong_rhino_version",
@@ -192,6 +192,17 @@ public class ProxyDispatcher(
     private sealed class SlotNotFoundException(string slotId) : Exception($"No slot named '{slotId}'")
     {
         public string SlotId { get; } = slotId;
+    }
+
+    private static bool IsVersionCompatible(string actual, string required)
+    {
+        if (actual == required) return true;
+        return (actual, required) switch
+        {
+            ("9", "WIP") => true,
+            ("WIP", "9") => true,
+            _ => false,
+        };
     }
 
     // Detect transport-level failures (DNS, refused, reset, timeout) — these mean

--- a/rhino/router/ProxyDispatcher.cs
+++ b/rhino/router/ProxyDispatcher.cs
@@ -58,22 +58,22 @@ public class ProxyDispatcher(
                 }
             }
 
-            var requestId = Guid.NewGuid().ToString("N");
-            var rpc = new JsonRpcRequest(
+            string requestId = Guid.NewGuid().ToString("N");
+            JsonRpcRequest rpc = new(
                 Jsonrpc: "2.0",
                 Id: requestId,
                 Method: "tools/call",
                 Params: new JsonRpcRequestParams(Name: toolName, Arguments: args));
 
-            var json = JsonSerializer.Serialize(rpc, RouterJsonContext.Default.JsonRpcRequest);
+            string json = JsonSerializer.Serialize(rpc, RouterJsonContext.Default.JsonRpcRequest);
             log.LogDebug("Proxying tool '{Tool}' to slot '{Slot}' at {Endpoint}: {Body}",
                 toolName, slotId, child.Endpoint, json);
 
-            var http = httpFactory.CreateClient();
+            HttpClient http = httpFactory.CreateClient();
             http.Timeout = TimeSpan.FromMinutes(5); // some tool calls can run long Python scripts
 
-            using var content = new StringContent(json, Encoding.UTF8, "application/json");
-            using var request = new HttpRequestMessage(HttpMethod.Post, child.Endpoint + "/")
+            using StringContent content = new(json, Encoding.UTF8, "application/json");
+            using HttpRequestMessage request = new(HttpMethod.Post, child.Endpoint + "/")
             {
                 Content = content
             };
@@ -100,7 +100,7 @@ public class ProxyDispatcher(
 
             using (response)
             {
-                var responseBody = await response.Content.ReadAsStringAsync(ct);
+                string responseBody = await response.Content.ReadAsStringAsync(ct);
 
                 if (!response.IsSuccessStatusCode)
                 {
@@ -122,7 +122,7 @@ public class ProxyDispatcher(
         catch (Exception ex)
         {
             log.LogWarning(ex, "Tool call '{Tool}' (slot '{Slot}') failed", toolName, slotId ?? "(default)");
-            return SerializePayload(DiagnoseFailure(ex, child, toolName));
+            return SerializePayload(DiagnoseFailure(ex, toolName));
         }
     }
 
@@ -144,7 +144,7 @@ public class ProxyDispatcher(
     // same SpawnErrorPayload shape SpawnSlotTool emits. Codes are kebab-case so
     // an agent can branch on them. Messages always end with what the agent
     // should do next.
-    private SpawnErrorPayload DiagnoseFailure(Exception ex, ChildRhino? child, string toolName) => ex switch
+    private SpawnErrorPayload DiagnoseFailure(Exception ex, string toolName) => ex switch
     {
         SlotNotFoundException snf => new(
             "slot_not_found",
@@ -196,7 +196,8 @@ public class ProxyDispatcher(
 
     private static bool IsVersionCompatible(string actual, string required)
     {
-        if (actual == required) return true;
+        if (actual == required)
+            return true;
         return (actual, required) switch
         {
             ("9", "WIP") => true,
@@ -211,12 +212,16 @@ public class ProxyDispatcher(
     // also unwrapped here for belt-and-braces.
     private static bool IsConnectionFailure(HttpRequestException ex)
     {
-        if (ex.HttpRequestError == HttpRequestError.ConnectionError) return true;
-        if (ex.HttpRequestError == HttpRequestError.SecureConnectionError) return true;
+        if (ex.HttpRequestError == HttpRequestError.ConnectionError)
+            return true;
+        if (ex.HttpRequestError == HttpRequestError.SecureConnectionError)
+            return true;
         for (var inner = ex.InnerException; inner is not null; inner = inner.InnerException)
         {
-            if (inner is System.Net.Sockets.SocketException) return true;
-            if (inner is IOException) return true;
+            if (inner is System.Net.Sockets.SocketException)
+                return true;
+            if (inner is IOException)
+                return true;
         }
         return false;
     }
@@ -253,16 +258,16 @@ public class ProxyDispatcher(
 
     private static string ExtractFromJsonRpc(string rpcJson, string slotId, string toolName)
     {
-        using var doc = JsonDocument.Parse(rpcJson);
-        var root = doc.RootElement;
+        using JsonDocument doc = JsonDocument.Parse(rpcJson);
+        JsonElement root = doc.RootElement;
 
-        if (root.TryGetProperty("error", out var err))
+        if (root.TryGetProperty("error", out JsonElement err))
         {
             throw new InvalidOperationException(
                 $"Slot '{slotId}' tool '{toolName}' returned MCP error: {err.GetRawText()}");
         }
 
-        if (root.TryGetProperty("result", out var result))
+        if (root.TryGetProperty("result", out JsonElement result))
         {
             return result.GetRawText();
         }

--- a/rhino/router/ProxyDispatcher.cs
+++ b/rhino/router/ProxyDispatcher.cs
@@ -19,13 +19,18 @@ public class ProxyDispatcher(
         string? slotId,
         string toolName,
         JsonNode args,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? defaultVersionOverride = null)
     {
         // Every exit path returns a string the MCP SDK forwards to the agent
         // verbatim. The SDK swallows exception messages into a generic "An error
         // occurred invoking '<tool>'", so on failure we MUST return a structured
         // payload, not throw. The catch at the bottom of this method is the
         // safety net for anything we didn't anticipate.
+        //
+        // `defaultVersionOverride` is set by codegen for tools that need a
+        // specific Rhino when no slot is passed (GH2_* tools pin "WIP" so they
+        // don't try to run on Rhino 8). It has no effect when `slotId` is set.
         ChildRhino? child = null;
         try
         {
@@ -33,9 +38,25 @@ public class ProxyDispatcher(
             // call `run_python(script=...)` etc. without a prior spawn_slot. Note
             // this can throw the same spawn-time exceptions SpawnSlotTool handles
             // (timeout, file-not-found, etc.); the outer catch translates them.
-            child = slotId is null
-                ? await manager.GetOrCreateDefaultAsync(ct).ConfigureAwait(false)
-                : manager.Get(slotId) ?? throw new SlotNotFoundException(slotId);
+            if (slotId is null)
+            {
+                child = await manager.GetOrCreateDefaultAsync(defaultVersionOverride, ct).ConfigureAwait(false);
+            }
+            else
+            {
+                child = manager.Get(slotId) ?? throw new SlotNotFoundException(slotId);
+                // Explicit slot whose Rhino version doesn't match what this tool
+                // needs (GH2_* tools pin "WIP"). Short-circuit before forwarding —
+                // the plugin would otherwise return a generic "unknown tool" MCP
+                // error and the agent wouldn't know the cause was a version mismatch.
+                if (defaultVersionOverride is not null && child.Version != defaultVersionOverride)
+                {
+                    return SerializePayload(new SpawnErrorPayload(
+                        "wrong_rhino_version",
+                        $"Tool '{toolName}' only works on Rhino {defaultVersionOverride} but slot '{slotId}' is running Rhino {child.Version}. " +
+                        $"Omit the `slot` argument to auto-spawn Rhino {defaultVersionOverride}, or call spawn_slot with version=\"{defaultVersionOverride}\"."));
+                }
+            }
 
             var requestId = Guid.NewGuid().ToString("N");
             var rpc = new JsonRpcRequest(
@@ -114,7 +135,7 @@ public class ProxyDispatcher(
             Message:
                 $"Rhino slot '{child.SlotId}' (pid {child.Pid}, Rhino {child.Version}) is no longer responding — likely crashed mid-call to '{toolName}'. " +
                 "The stale slot has been pruned. " +
-                (child.SlotId == RhinoManager.DefaultSlotId
+                (child.SlotId.StartsWith(RhinoManager.DefaultSlotPrefix)
                     ? "Retry this call to auto-spawn a fresh default Rhino."
                     : "Call spawn_slot to start a new one."),
             CrashReport: crashFinder.TryFind(child.Pid));

--- a/rhino/router/README.md
+++ b/rhino/router/README.md
@@ -1,0 +1,23 @@
+# Router
+The Router offers a much more powerful agentic experience when using MCP servers with Rhino3D and Grasshopper 1/2. The Router is a io based MCP server that routes any MCP requests through to Rhino.
+
+## Advantages
+
+Having an IO based MCP Server outside of Rhino offers many distinct advantages
+1. IO can connect immediately, no need to restart Claude or Sync Rhino with it
+1. As the router is outside of Rhino, it can start Rhino for the user
+1. And as a bonus, it can run multiple Rhino instances at once
+1. The Router can handle Crash Recovery, if Rhino crashes the Agent is informed of this, and crucially, why so it can work around the crash and recover completely.
+1. The Router can start Rhino 8 and/or 9 instances at the same time, so upgrading or downgrading can be handled
+
+## Concurrency
+
+As the router is IO based, when an AI agent starts it will create a new instance of the router, which means multiple AI agents would each have their own instance with no shared state. To prevent issues with this, the router has no state inside of it, and stores all current state in a simple sqlite database. Meaning that multiple AI agents can each open their own rhinos and interact with them simultaneously.
+
+## Development notes
+
+- The Router has 0 rhino dependencies to keep it small.
+- It uses codegen to generate generic tool wrappers for itself from the rhino plugin source.
+- Rhino 8/9 get a slightly different router as 8 cannot access the latest G2 due to nuget.
+- The Router is published as NativeAOT on mac and a simple .exe on Win to minimize size and dependencies
+- 

--- a/rhino/router/README.md
+++ b/rhino/router/README.md
@@ -8,7 +8,7 @@ Having an IO based MCP Server outside of Rhino offers many distinct advantages
 1. As the router is outside of Rhino, it can start Rhino for the user
 1. And as a bonus, it can run multiple Rhino instances at once
 1. The Router can handle Crash Recovery, if Rhino crashes the Agent is informed of this, and crucially, why so it can work around the crash and recover completely.
-1. The Router can start Rhino 8 and/or 9 instances at the same time, so upgrading or downgrading can be handled
+1. The Router can start Rhino 8 and/or 9 instances at the same time, so upgrading or downgrading files, plugins etc can be done.
 
 ## Concurrency
 
@@ -20,4 +20,7 @@ As the router is IO based, when an AI agent starts it will create a new instance
 - It uses codegen to generate generic tool wrappers for itself from the rhino plugin source.
 - Rhino 8/9 get a slightly different router as 8 cannot access the latest G2 due to nuget.
 - The Router is published as NativeAOT on mac and a simple .exe on Win to minimize size and dependencies
-- 
+- arm64/x64 for Win should work fine
+
+## Debugging
+- Ensure you close your AI agent after each router rebuild, it must restart its instance

--- a/rhino/router/RhinoLocator.cs
+++ b/rhino/router/RhinoLocator.cs
@@ -8,55 +8,53 @@ public class RhinoLocator
 {
     public string ResolveRhinoExe(string version)
     {
-        var path = TryResolve(version);
-        if (path is null)
-        {
-            throw new FileNotFoundException(
-                $"Could not locate Rhino executable for version '{version}'. " +
-                $"Installed versions found: {string.Join(", ", ListInstalledVersions())}");
-        }
-        return path;
+        if (TryResolve(version, out string path))
+            return path;
+
+        throw new FileNotFoundException(
+            $"Could not locate Rhino executable for version '{version}'. " +
+            $"Installed versions found: {string.Join(", ", ListInstalledVersions())}");
     }
 
-    private string? TryResolve(string version)
+    private bool TryResolve(string version, out string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             // TODO: also try registry-based lookup if Program Files paths miss.
-            var dir = version switch
+            string dir = version switch
             {
                 "8" => @"C:\Program Files\Rhino 8",
                 "9" => @"C:\Program Files\Rhino 9",
                 "WIP" => @"C:\Program Files\Rhino 9 WIP",
-                _ => null
+                _ => string.Empty
             };
-            if (dir is null) return null;
-            var exe = Path.Combine(dir, "System", "Rhino.exe");
-            return File.Exists(exe) ? exe : null;
+            path = Path.Combine(dir, "System", "Rhino.exe");
+            return File.Exists(path);
         }
 
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            var appName = version switch
+            string appName = version switch
             {
                 "8" => "Rhino 8.app",
                 "9" => "Rhino 9.app",
                 "WIP" => "RhinoWIP.app",
-                _ => null
+                _ => string.Empty
             };
-            if (appName is null) return null;
-            var appPath = $"/Applications/{appName}";
-            return Directory.Exists(appPath) ? appPath : null;
+            path = $"/Applications/{appName}";
+            return Directory.Exists(path);
         }
 
-        return null;
+        path = string.Empty;
+        return false;
     }
 
     public IEnumerable<string> ListInstalledVersions()
     {
-        foreach (var v in new[] { "8", "9", "WIP" })
+        foreach (string v in new[] { "8", "9", "WIP" })
         {
-            if (TryResolve(v) is not null) yield return v;
+            if (TryResolve(v, out _))
+                yield return v;
         }
     }
 }

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -2,11 +2,17 @@ using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 
 namespace RhMcp.Router;
 
 // Spawns, tracks, and tears down Rhino "slots".
+//
+// State lives in SlotStore (SQLite) so concurrent router processes — one per
+// Claude Code session — can't race on port allocation or duplicate-spawn the
+// Mac shared-process lead. The manager itself holds no in-memory registry;
+// every read/write goes through the store under BEGIN IMMEDIATE.
 //
 // Process model differs by OS:
 //   Windows: one OS process per slot. Each child gets its own RhinoDoc on its
@@ -15,26 +21,15 @@ namespace RhMcp.Router;
 //            per bundle id). The first slot for a version launches the .app;
 //            subsequent slots for the same version share that pid and ask the
 //            existing listener to spawn another doc + listener via the
-//            _router_spawn_listener control tool.
+//            _router_spawn_listener control tool. The "first slot" is decided
+//            inside SlotStore.Reserve so two routers can't both claim leader.
 public class RhinoManager(
     RhinoLocator locator,
     RouterConfig config,
     RhinoControlClient control,
+    SlotStore store,
     ILogger<RhinoManager> log)
 {
-    private readonly Dictionary<string, ChildRhino> _children = new();
-    private readonly object _lock = new();
-
-    // Serialises GetOrCreateDefault so two slot-less tool calls arriving at once
-    // don't both spawn their own default Rhino.
-    private readonly SemaphoreSlim _defaultGate = new(1, 1);
-
-    // Serialises Mac spawn flow so concurrent SpawnAsync calls for the same
-    // version can't both decide there's no lead listener and both try to launch
-    // a fresh Rhino. Cheap (only Mac uses it) and we never await long-running
-    // work outside it on Mac.
-    private readonly SemaphoreSlim _macSpawnGate = new(1, 1);
-
     // Slot-id prefix for the auto-spawned default Rhino used by tool calls that
     // don't pass an explicit slot. The version is appended so a GH2 tool that
     // needs WIP gets its own default slot (e.g. "default-WIP") rather than
@@ -46,9 +41,20 @@ public class RhinoManager(
     // router-spawned children land on 10501, 10502, ... without colliding.
     private const int ChildPortBase = 10500;
     private const int SpawnTimeoutSeconds = 60;
+    private static readonly TimeSpan StaleLaunchingMaxAge = TimeSpan.FromSeconds(90);
 
-    public Task<ChildRhino> SpawnAsync(string? version = null, CancellationToken ct = default) =>
-        SpawnInternalAsync(version ?? config.DefaultVersion, AnimalNames.Next(), ct);
+    private readonly int _routerPid = Environment.ProcessId;
+
+    public Task<ChildRhino> SpawnAsync(string? version = null, CancellationToken ct = default)
+    {
+        var resolved = version ?? config.DefaultVersion;
+        // Name allocation lives in the store (cross-router-safe). We use the
+        // returned slot_id as-is; no separate AnimalNames.Next() per process.
+        store.ReapStaleLaunching(StaleLaunchingMaxAge);
+        ReapAllDead();
+        var (reservation, slotId) = store.ReserveNewNamed(resolved, _routerPid);
+        return DispatchReservationAsync(resolved, slotId, reservation, ct);
+    }
 
     // Lazily return the default slot for `version`, spawning a Rhino if one doesn't already exist.
     // Called by ProxyDispatcher when a tool is invoked without an explicit slot. A null version
@@ -63,91 +69,91 @@ public class RhinoManager(
         string resolved = version ?? config.DefaultVersion;
         string slotId = DefaultSlotPrefix + resolved;
 
-        lock (_lock)
-        {
-            if (TryPickDefault(slotId, resolved, out var existing)) return existing;
-        }
+        // Prefer an adopted user-started Rhino on the matching version over
+        // spawning our own — see class comment.
+        var adopted = store.ListReady().FirstOrDefault(c => c.Adopted && c.Version == resolved);
+        if (adopted is not null) return adopted;
 
-        await _defaultGate.WaitAsync(ct).ConfigureAwait(false);
-        try
-        {
-            // Re-check under the gate — another caller may have spawned (or an
-            // announcement may have been adopted) while we waited.
-            lock (_lock)
-            {
-                if (TryPickDefault(slotId, resolved, out var existing)) return existing;
-            }
-            return await SpawnInternalAsync(resolved, slotId, ct).ConfigureAwait(false);
-        }
-        finally
-        {
-            _defaultGate.Release();
-        }
-    }
-
-    // Caller must hold _lock. Picks the slot a slot-less tool call should route
-    // to: the reserved per-version default slot first, otherwise any adopted
-    // user-started Rhino on the matching version.
-    private bool TryPickDefault(string slotId, string version, out ChildRhino slot)
-    {
-        if (_children.TryGetValue(slotId, out var def))
-        {
-            slot = def;
-            return true;
-        }
-        var adopted = _children.Values.FirstOrDefault(
-            c => c.Adopted && c.Version == version);
-        if (adopted is not null)
-        {
-            slot = adopted;
-            return true;
-        }
-        slot = default!;
-        return false;
+        return await SpawnInternalAsync(resolved, slotId, ct).ConfigureAwait(false);
     }
 
     private async Task<ChildRhino> SpawnInternalAsync(string version, string slotId, CancellationToken ct)
     {
-        // Prune stale slot entries before deciding what to do. Without this, a Mac
-        // slot whose Rhino crashed earlier in the session stays in the registry,
-        // and SpawnMacAsync would try to reuse its dead control endpoint —
-        // surfacing as a confusing "Connection refused (localhost:10500)" deep
-        // inside RhinoControlClient.SpawnListenerAsync.
+        // Drop stale placeholders before deciding what to do, so a crashed
+        // router's abandoned 'launching' row doesn't make this caller wait 90s.
+        store.ReapStaleLaunching(StaleLaunchingMaxAge);
         ReapAllDead();
 
-        var rhinoExe = locator.ResolveRhinoExe(version);
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            var port = PickFreePort();
-            log.LogInformation("Spawning Rhino {Version} as slot '{Slot}' on port {Port} (exe: {Exe})",
-                version, slotId, port, rhinoExe);
-            var proc = LaunchWindows(rhinoExe, port);
-            return WaitAndRegister(slotId, version, port, proc.Id);
-        }
-
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return await SpawnMacAsync(rhinoExe, version, slotId, ct).ConfigureAwait(false);
-        }
-
-        throw new PlatformNotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
+        var reservation = store.Reserve(slotId, version, _routerPid);
+        return await DispatchReservationAsync(version, slotId, reservation, ct).ConfigureAwait(false);
     }
 
-    private async Task<ChildRhino> SpawnMacAsync(string appPath, string version, string slotId, CancellationToken ct)
+    // Shared post-reservation branch. Both SpawnAsync (auto-named via the name
+    // pool) and SpawnInternalAsync (known slot_id, e.g. 'default-WIP') funnel
+    // through here so the existing/leader/follower handling lives in one place.
+    private async Task<ChildRhino> DispatchReservationAsync(
+        string version, string slotId, SlotReservation reservation, CancellationToken ct)
     {
-        await _macSpawnGate.WaitAsync(ct).ConfigureAwait(false);
+        switch (reservation.Kind)
+        {
+            case SlotReservation.ReservationKind.Existing:
+                return await UseOrAwaitExisting(reservation.ExistingSlot!, ct).ConfigureAwait(false);
+
+            case SlotReservation.ReservationKind.Leader:
+                return await LaunchAsLeaderAsync(version, slotId, ct).ConfigureAwait(false);
+
+            case SlotReservation.ReservationKind.Follower:
+                return await LaunchAsFollowerAsync(version, slotId, ct).ConfigureAwait(false);
+
+            default:
+                throw new InvalidOperationException($"Unknown reservation kind: {reservation.Kind}");
+        }
+    }
+
+    private async Task<ChildRhino> UseOrAwaitExisting(ChildRhino existing, CancellationToken ct)
+    {
+        if (existing.Status == SlotStatus.Ready) return existing;
+
+        var ready = store.WaitForReady(existing.SlotId, TimeSpan.FromSeconds(SpawnTimeoutSeconds), ct);
+        if (ready is null)
+        {
+            throw new TimeoutException(
+                $"Slot '{existing.SlotId}' was already being launched by another router but never became ready " +
+                $"within {SpawnTimeoutSeconds}s.");
+        }
+        return ready;
+    }
+
+    private async Task<ChildRhino> LaunchAsLeaderAsync(string version, string slotId, CancellationToken ct)
+    {
         try
         {
-            ChildRhino? lead;
-            lock (_lock) lead = _children.Values.FirstOrDefault(c => c.Version == version);
+            var rhinoExe = locator.ResolveRhinoExe(version);
 
-            if (lead is null)
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var port = PickFreePort();
+                var port = store.ReservePort(slotId, ChildPortBase, IsPortListening);
+                log.LogInformation("Spawning Rhino {Version} as slot '{Slot}' on port {Port} (exe: {Exe})",
+                    version, slotId, port, rhinoExe);
+                var proc = LaunchWindows(rhinoExe, port);
+                if (!WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)))
+                {
+                    try { proc.Kill(); } catch { /* best effort */ }
+                    throw new TimeoutException(
+                        $"Rhino {version} (pid {proc.Id}) did not bind port {port} within {SpawnTimeoutSeconds}s. " +
+                        $"Possible causes: plugin missing, plugin failed to init, license dialog, slow disk.");
+                }
+                store.MarkReady(slotId, port, proc.Id);
+                log.LogInformation("Slot '{Slot}' ready: pid {Pid}, port {Port}", slotId, proc.Id, port);
+                return store.Get(slotId)!;
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                var port = store.ReservePort(slotId, ChildPortBase, IsPortListening);
                 log.LogInformation("Launching Rhino {Version} as slot '{Slot}' on port {Port} (app: {App})",
-                    version, slotId, port, appPath);
-                LaunchMac(appPath, port);
+                    version, slotId, port, rhinoExe);
+                LaunchMac(rhinoExe, port);
                 if (!WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)))
                 {
                     throw new TimeoutException(
@@ -160,48 +166,72 @@ public class RhinoManager(
                     throw new InvalidOperationException(
                         $"Rhino bound port {port} but lsof could not resolve the pid.");
                 }
-                var first = new ChildRhino(slotId, port, pid, version);
-                lock (_lock) _children[slotId] = first;
+                store.MarkReady(slotId, port, pid);
                 log.LogInformation("Slot '{Slot}' ready: pid {Pid}, port {Port}", slotId, pid, port);
-                return first;
+                return store.Get(slotId)!;
             }
 
-            log.LogInformation("Mac: reusing Rhino {Version} (pid {Pid}) for slot '{Slot}'",
-                version, lead.Pid, slotId);
-            var newPort = await control.SpawnListenerAsync(lead.Endpoint, ct).ConfigureAwait(false);
-            var child = new ChildRhino(slotId, newPort, lead.Pid, version);
-            lock (_lock) _children[slotId] = child;
-            log.LogInformation("Slot '{Slot}' ready: pid {Pid} (shared), port {Port}", slotId, lead.Pid, newPort);
-            return child;
+            throw new PlatformNotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
         }
-        finally
+        catch
         {
-            _macSpawnGate.Release();
+            // Free the placeholder so the next caller can retry instead of
+            // waiting 90s for the stale-launching reaper.
+            store.Delete(slotId);
+            throw;
         }
     }
 
-    private ChildRhino WaitAndRegister(string slotId, string version, int port, int pid)
+    private async Task<ChildRhino> LaunchAsFollowerAsync(string version, string slotId, CancellationToken ct)
     {
-        if (!WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)))
+        // Mac-only path: another reservation for this version exists. Wait
+        // until at least one ready row for this version appears (it'll be the
+        // leader we follow), then ask that listener to spawn a sibling.
+        try
         {
-            try { Process.GetProcessById(pid).Kill(); } catch { /* best effort */ }
-            throw new TimeoutException(
-                $"Rhino {version} (pid {pid}) did not bind port {port} within {SpawnTimeoutSeconds}s. " +
-                $"Possible causes: plugin missing, plugin failed to init, license dialog, slow disk.");
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                // On Windows every slot is its own process, so "follower" makes
+                // no sense — promote to leader behavior. SlotStore only returns
+                // Follower when peers exist, which on Windows would still mean
+                // distinct processes, distinct ports.
+                return await LaunchAsLeaderAsync(version, slotId, ct).ConfigureAwait(false);
+            }
+
+            var lead = await WaitForLeadAsync(version, slotId, ct).ConfigureAwait(false);
+            log.LogInformation("Mac: reusing Rhino {Version} (pid {Pid}) for slot '{Slot}'",
+                version, lead.Pid, slotId);
+
+            var newPort = await control.SpawnListenerAsync(lead.Endpoint, ct).ConfigureAwait(false);
+            store.MarkReady(slotId, newPort, lead.Pid);
+            log.LogInformation("Slot '{Slot}' ready: pid {Pid} (shared), port {Port}", slotId, lead.Pid, newPort);
+            return store.Get(slotId)!;
         }
-        var child = new ChildRhino(slotId, port, pid, version);
-        lock (_lock) _children[slotId] = child;
-        log.LogInformation("Slot '{Slot}' ready: pid {Pid}, port {Port}", slotId, pid, port);
-        return child;
+        catch
+        {
+            store.Delete(slotId);
+            throw;
+        }
+    }
+
+    private async Task<ChildRhino> WaitForLeadAsync(string version, string slotId, CancellationToken ct)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(SpawnTimeoutSeconds);
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            var lead = store.FindReadyLead(version, slotId);
+            if (lead is not null) return lead;
+            await Task.Delay(200, ct).ConfigureAwait(false);
+        }
+        throw new TimeoutException(
+            $"Slot '{slotId}' waited {SpawnTimeoutSeconds}s for a sibling Rhino {version} to become ready but none did.");
     }
 
     public async Task<bool> CloseAsync(string slotId, CancellationToken ct = default)
     {
-        ChildRhino? child;
-        lock (_lock)
-        {
-            if (!_children.TryGetValue(slotId, out child)) return false;
-        }
+        var child = store.Get(slotId);
+        if (child is null) return false;
 
         if (child.Adopted)
         {
@@ -216,12 +246,7 @@ public class RhinoManager(
             // Find sibling slots sharing this pid. If any exist, this isn't the last
             // slot in the Rhino process — close just this listener via the control
             // channel and keep Rhino running.
-            ChildRhino? sibling;
-            lock (_lock)
-            {
-                sibling = _children.Values.FirstOrDefault(c => c.Pid == child.Pid && c.SlotId != slotId);
-            }
-
+            var sibling = store.FindSiblingByPid(slotId, child.Pid);
             if (sibling is not null)
             {
                 log.LogInformation("Closing slot '{Slot}' listener on port {Port} (pid {Pid} shared with '{Sibling}')",
@@ -229,7 +254,7 @@ public class RhinoManager(
                 try
                 {
                     await control.CloseListenerAsync(sibling.Endpoint, child.Port, ct).ConfigureAwait(false);
-                    lock (_lock) _children.Remove(slotId);
+                    store.Delete(slotId);
                     return true;
                 }
                 catch (Exception ex)
@@ -241,7 +266,7 @@ public class RhinoManager(
             // Last slot for this Rhino — fall through to process kill below.
         }
 
-        lock (_lock) _children.Remove(slotId);
+        store.Delete(slotId);
         log.LogInformation("Closing slot '{Slot}' (pid {Pid})", slotId, child.Pid);
         try
         {
@@ -257,23 +282,18 @@ public class RhinoManager(
 
     public void CloseAll()
     {
-        // Shutdown path: kill each unique pid once. No control-channel niceties —
-        // we're tearing everything down anyway, and multiple slots may share a pid on Mac.
-        // Adopted slots are skipped: the user owns those Rhinos, so router shutdown
-        // must not take them down.
-        string[] ids;
-        lock (_lock) ids = _children.Keys.ToArray();
-
+        // Shutdown path: kill each unique pid this router owns once. No control-channel
+        // niceties — we're tearing everything down anyway, and multiple slots may share a
+        // pid on Mac. Adopted slots are skipped: the user owns those Rhinos. Slots owned
+        // by *other* routers are also skipped — they're not ours to kill, and their owners
+        // will tear them down on their own shutdown.
+        var owned = store.ListAllOwnedBy(_routerPid);
         var killed = new HashSet<int>();
-        foreach (var id in ids)
+        foreach (var c in owned)
         {
-            ChildRhino? c;
-            lock (_lock)
-            {
-                if (!_children.TryGetValue(id, out c)) continue;
-                if (c.Adopted) { _children.Remove(id); continue; }
-                _children.Remove(id);
-            }
+            if (c.Adopted) { store.Delete(c.SlotId); continue; }
+            store.Delete(c.SlotId);
+            if (c.Pid <= 0) continue;
             if (!killed.Add(c.Pid)) continue;
             try
             {
@@ -287,26 +307,24 @@ public class RhinoManager(
         }
     }
 
-    public IReadOnlyCollection<ChildRhino> List()
-    {
-        lock (_lock) return _children.Values.ToArray();
-    }
+    public IReadOnlyCollection<ChildRhino> List() => store.ListReady();
 
     public ChildRhino? Get(string slotId)
     {
-        lock (_lock) return _children.GetValueOrDefault(slotId);
+        var c = store.Get(slotId);
+        return c is null || c.Status != SlotStatus.Ready ? null : c;
     }
 
     // Walk the listener-announcement drop directory and adopt any plugin-side
     // Rhino we don't already know about. The plugin writes one file per
-    // listener-bind into <temp>/rhino-mcp-listeners; we treat each file as a
+    // listener-bind into <temp>/rhino-mcp/listeners; we treat each file as a
     // one-shot "look at me" doorbell — consume by deleting it whether or not
     // adoption succeeded. Stale files (port no longer listening) are dropped
     // silently; files for a pid+port we already track are deleted as a no-op so
     // the Mac _router_spawn_listener path remains idempotent.
     public void ScanAnnouncements()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "rhino-mcp-listeners");
+        var dir = RouterPaths.ListenersDir;
         if (!Directory.Exists(dir)) return;
 
         string[] files;
@@ -340,20 +358,6 @@ public class RhinoManager(
                     continue;
                 }
 
-                bool alreadyKnown;
-                lock (_lock)
-                {
-                    alreadyKnown = _children.Values.Any(c => c.Pid == ann.Pid && c.Port == ann.Port);
-                }
-
-                if (alreadyKnown)
-                {
-                    // Mac _router_spawn_listener case (and any other duplicate) —
-                    // file is harmless once consumed.
-                    TryDelete(file);
-                    continue;
-                }
-
                 if (!IsPortListening(ann.Port))
                 {
                     log.LogDebug("Announcement for pid {Pid} port {Port} is stale (no listener); discarding",
@@ -362,11 +366,16 @@ public class RhinoManager(
                     continue;
                 }
 
-                var slotId = AnimalNames.Next();
-                var child = new ChildRhino(slotId, ann.Port, ann.Pid, ann.Version ?? "?", Adopted: true);
-                lock (_lock) _children[slotId] = child;
-                log.LogInformation("Adopted user-started Rhino {Version} as slot '{Slot}' (pid {Pid}, port {Port})",
-                    child.Version, slotId, ann.Pid, ann.Port);
+                // AdoptIfNew handles the duplicate-(pid,port) check, name
+                // allocation, and the INSERT atomically. Returns null when the
+                // listener is already in the registry (Mac _router_spawn_listener
+                // duplicate, or another router already adopted it).
+                var slotId = store.AdoptIfNew(ann.Version ?? "?", ann.Port, ann.Pid, _routerPid);
+                if (slotId is not null)
+                {
+                    log.LogInformation("Adopted user-started Rhino {Version} as slot '{Slot}' (pid {Pid}, port {Port})",
+                        ann.Version ?? "?", slotId, ann.Pid, ann.Port);
+                }
                 TryDelete(file);
             }
             catch (Exception ex)
@@ -389,6 +398,7 @@ public class RhinoManager(
     // stuck process could leave the socket bound).
     public bool IsAlive(ChildRhino c)
     {
+        if (c.Status != SlotStatus.Ready) return true; // launching rows aren't "dead", just pending
         if (!IsProcessAlive(c.Pid)) return false;
         if (!IsPortListening(c.Port)) return false;
         return true;
@@ -399,39 +409,26 @@ public class RhinoManager(
     // error, so the next tool call doesn't keep hitting the same dead slot.
     public bool TryReapDead(string slotId)
     {
-        ChildRhino? c;
-        lock (_lock)
-        {
-            if (!_children.TryGetValue(slotId, out c)) return false;
-        }
+        var c = store.Get(slotId);
+        if (c is null) return false;
         if (IsAlive(c)) return false;
-        lock (_lock) _children.Remove(slotId);
+        store.Delete(slotId);
         log.LogWarning("Reaped dead slot '{Slot}' (pid {Pid}, port {Port}, Rhino {Version})",
             c.SlotId, c.Pid, c.Port, c.Version);
         return true;
     }
 
-    // Probe every slot, drop the dead ones, return what was reaped. Called by
-    // list_slots so a silently-crashed Rhino doesn't appear healthy until the
+    // Probe every ready slot, drop the dead ones, return what was reaped. Called
+    // by list_slots so a silently-crashed Rhino doesn't appear healthy until the
     // next tool call.
     public IReadOnlyCollection<ChildRhino> ReapAllDead()
     {
-        ChildRhino[] snapshot;
-        lock (_lock) snapshot = _children.Values.ToArray();
-
         var reaped = new List<ChildRhino>();
-        foreach (var c in snapshot)
+        foreach (var c in store.ListReady())
         {
             if (IsAlive(c)) continue;
-            lock (_lock)
-            {
-                // Recheck under lock — could have been removed by a concurrent close.
-                if (_children.TryGetValue(c.SlotId, out var current) && ReferenceEquals(current, c))
-                {
-                    _children.Remove(c.SlotId);
-                    reaped.Add(c);
-                }
-            }
+            store.Delete(c.SlotId);
+            reaped.Add(c);
         }
         if (reaped.Count > 0)
         {
@@ -522,22 +519,6 @@ public class RhinoManager(
         return 0;
     }
 
-    private int PickFreePort()
-    {
-        var taken = new HashSet<int>();
-        lock (_lock)
-        {
-            foreach (var c in _children.Values) taken.Add(c.Port);
-        }
-
-        for (int p = ChildPortBase; p < 65000; p++)
-        {
-            if (taken.Contains(p)) continue;
-            if (!IsPortListening(p)) return p;
-        }
-        throw new InvalidOperationException("No free ports available in spawn range.");
-    }
-
     private static bool WaitForPort(int port, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -578,7 +559,17 @@ public sealed class AdoptedSlotCloseException(string slotId)
 // announcement rather than spawning it. Adopted slots are never killed by the
 // router (CloseAll skips them; close_slot refuses) — the user started them, the
 // user closes them.
-public record ChildRhino(string SlotId, int Port, int Pid, string Version, bool Adopted = false)
+//
+// `Status` is internal lifecycle state (launching/ready). It's kept off the
+// JSON wire so list_slots output stays the same shape as before — agents
+// shouldn't see 'launching' rows because ListReady already filters them out.
+public record ChildRhino(
+    string SlotId,
+    int Port,
+    int Pid,
+    string Version,
+    bool Adopted = false,
+    [property: JsonIgnore] string Status = SlotStatus.Ready)
 {
     public string Endpoint => $"http://localhost:{Port}";
 }

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -449,15 +449,20 @@ public class RhinoManager(
         catch (InvalidOperationException) { return false; }
     }
 
+    // Env var consumed by StartMCPCommand inside the plugin to autostart the listener.
+    // Must match StartMCPCommand.PortEnvVar in rhino/plugin/StartMCPCommand.cs.
+    private const string PortEnvVar = "RHINO_MCP_AUTOSTART_PORT";
+
     private static Process LaunchWindows(string rhinoExe, int port)
     {
         var psi = new ProcessStartInfo
         {
             FileName = rhinoExe,
-            Arguments = $"/nosplash /runscript=\"_RhinoMCP {port} _Enter\"",
-            UseShellExecute = true,
+            Arguments = $"/nosplash /runscript=\"_StartMCP\"",
+            UseShellExecute = false,
             WindowStyle = ProcessWindowStyle.Normal,
         };
+        psi.Environment[PortEnvVar] = port.ToString();
 
         return Process.Start(psi)
             ?? throw new InvalidOperationException($"Process.Start returned null for {rhinoExe}");
@@ -465,8 +470,9 @@ public class RhinoManager(
 
     // Launches Rhino.app via `open -a`. We don't get a usable Process handle back —
     // `open` exits immediately and the Rhino pid is resolved later by lsof against
-    // the listening port. ArgumentList ensures the runscript value (which contains
-    // spaces) survives as a single argv element.
+    // the listening port. The port is delivered via env var rather than as a runscript
+    // argument because feeding integer args through the runscript engine races with
+    // plugin command registration; StartMCP reads the env var directly.
     private static void LaunchMac(string appPath, int port)
     {
         var psi = new ProcessStartInfo
@@ -474,11 +480,12 @@ public class RhinoManager(
             FileName = "/usr/bin/open",
             UseShellExecute = false,
         };
+        psi.Environment[PortEnvVar] = port.ToString();
         psi.ArgumentList.Add("-a");
         psi.ArgumentList.Add(appPath);
         psi.ArgumentList.Add("--args");
         psi.ArgumentList.Add("-nosplash");
-        psi.ArgumentList.Add($"-runscript=_RhinoMCP {port} _Enter");
+        psi.ArgumentList.Add("-runscript=_StartMCP");
 
         using var proc = Process.Start(psi)
             ?? throw new InvalidOperationException($"Failed to start `open -a {appPath}`.");

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -35,9 +35,11 @@ public class RhinoManager(
     // work outside it on Mac.
     private readonly SemaphoreSlim _macSpawnGate = new(1, 1);
 
-    // Reserved slot id for the auto-spawned default Rhino used by tool calls that
-    // don't pass an explicit slot.
-    public const string DefaultSlotId = "default";
+    // Slot-id prefix for the auto-spawned default Rhino used by tool calls that
+    // don't pass an explicit slot. The version is appended so a GH2 tool that
+    // needs WIP gets its own default slot (e.g. "default-WIP") rather than
+    // colliding with a non-GH2 tool's "default-8".
+    public const string DefaultSlotPrefix = "default-";
 
     // Children walk forward from the conventional RhinoMCP port (10500) to find a free one.
     // A user who started a Rhino manually via `_RhinoMCP` will already be on 10500, so the
@@ -48,18 +50,21 @@ public class RhinoManager(
     public Task<ChildRhino> SpawnAsync(string? version = null, CancellationToken ct = default) =>
         SpawnInternalAsync(version ?? config.DefaultVersion, AnimalNames.Next(), ct);
 
-    // Lazily return the default slot, spawning a Rhino for it if one doesn't already exist.
-    // Called by ProxyDispatcher when a tool is invoked without an explicit slot.
-    // Adopted Rhinos are deliberately not promoted to the default slot — slot-less
-    // calls still spawn a fresh router-owned Rhino so the user's manually-started
-    // session isn't hijacked.
-    public async Task<ChildRhino> GetOrCreateDefaultAsync(CancellationToken ct = default)
+    // Lazily return the default slot for `version`, spawning a Rhino if one doesn't already exist.
+    // Called by ProxyDispatcher when a tool is invoked without an explicit slot. A null version
+    // resolves to the router's configured default. GH2 tool proxies pass "WIP" so they get a
+    // separate default slot from non-GH2 tools. Adopted Rhinos are deliberately not promoted to
+    // the default slot — slot-less calls still spawn a fresh router-owned Rhino so the user's
+    // manually-started session isn't hijacked.
+    public async Task<ChildRhino> GetOrCreateDefaultAsync(string? version = null, CancellationToken ct = default)
     {
         ScanAnnouncements();
+        string resolved = version ?? config.DefaultVersion;
+        string slotId = DefaultSlotPrefix + resolved;
 
         lock (_lock)
         {
-            if (_children.TryGetValue(DefaultSlotId, out var existing)) return existing;
+            if (_children.TryGetValue(slotId, out var existing)) return existing;
         }
 
         await _defaultGate.WaitAsync(ct).ConfigureAwait(false);
@@ -68,9 +73,9 @@ public class RhinoManager(
             // Re-check under the gate — another caller may have spawned while we waited.
             lock (_lock)
             {
-                if (_children.TryGetValue(DefaultSlotId, out var existing)) return existing;
+                if (_children.TryGetValue(slotId, out var existing)) return existing;
             }
-            return await SpawnInternalAsync(config.DefaultVersion, DefaultSlotId, ct).ConfigureAwait(false);
+            return await SpawnInternalAsync(resolved, slotId, ct).ConfigureAwait(false);
         }
         finally
         {

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -136,12 +136,31 @@ public class RhinoManager(
                 log.LogInformation("Spawning Rhino {Version} as slot '{Slot}' on port {Port} (exe: {Exe})",
                     version, slotId, port, rhinoExe);
                 var proc = LaunchWindows(rhinoExe, port);
-                if (!WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)))
+                switch (WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds), proc))
                 {
-                    try { proc.Kill(); } catch { /* best effort */ }
-                    throw new TimeoutException(
-                        $"Rhino {version} (pid {proc.Id}) did not bind port {port} within {SpawnTimeoutSeconds}s. " +
-                        $"Possible causes: plugin missing, plugin failed to init, license dialog, slow disk.");
+                    case WaitResult.Bound:
+                        break;
+                    case WaitResult.ProcessDied:
+                        throw new TimeoutException(
+                            $"Rhino {version} (pid {proc.Id}) exited with code {proc.ExitCode} before binding port {port}. " +
+                            $"Possible causes: startup crash, missing runtime dependency, license/EULA refused, " +
+                            $"plugin load failure.");
+                    case WaitResult.Timeout:
+                        // Re-read MainWindowHandle: it's cached on first access, so a
+                        // refresh covers the case where the window appeared after we
+                        // first observed the Process. A zero handle here means Rhino
+                        // is running headless from our perspective — usually because
+                        // the parent process tree (e.g. an IDE extension host) hasn't
+                        // given the child interactive-desktop access.
+                        proc.Refresh();
+                        bool hasWindow = proc.MainWindowHandle != IntPtr.Zero;
+                        try { proc.Kill(); } catch { /* best effort */ }
+                        throw new TimeoutException(hasWindow
+                            ? $"Rhino {version} (pid {proc.Id}) has a main window but did not bind port {port} within {SpawnTimeoutSeconds}s. " +
+                              $"Possible causes: license/EULA dialog blocking, plugin failed to load, runscript stuck."
+                            : $"Rhino {version} (pid {proc.Id}) is running but never created a main window. " +
+                              $"Likely the router was launched from a process context without interactive-desktop access " +
+                              $"(IDE extension host, service, or session-0). Try launching the router from a regular terminal to confirm.");
                 }
                 store.MarkReady(slotId, port, proc.Id);
                 log.LogInformation("Slot '{Slot}' ready: pid {Pid}, port {Port}", slotId, proc.Id, port);
@@ -154,7 +173,7 @@ public class RhinoManager(
                 log.LogInformation("Launching Rhino {Version} as slot '{Slot}' on port {Port} (app: {App})",
                     version, slotId, port, rhinoExe);
                 LaunchMac(rhinoExe, port);
-                if (!WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)))
+                if (WaitForPort(port, TimeSpan.FromSeconds(SpawnTimeoutSeconds)) != WaitResult.Bound)
                 {
                     throw new TimeoutException(
                         $"Rhino {version} did not bind port {port} within {SpawnTimeoutSeconds}s. " +
@@ -455,17 +474,13 @@ public class RhinoManager(
 
     private static Process LaunchWindows(string rhinoExe, int port)
     {
-        var psi = new ProcessStartInfo
-        {
-            FileName = rhinoExe,
-            Arguments = $"/nosplash /runscript=\"_StartMCP\"",
-            UseShellExecute = false,
-            WindowStyle = ProcessWindowStyle.Normal,
-        };
-        psi.Environment[PortEnvVar] = port.ToString();
-
-        return Process.Start(psi)
-            ?? throw new InvalidOperationException($"Process.Start returned null for {rhinoExe}");
+        // CreateProcess + CREATE_BREAKAWAY_FROM_JOB so Rhino escapes the Job
+        // Object the router inherited from its parent (Claude Code / VS Code
+        // extension host). See WinSpawn for the rationale.
+        return WinSpawn.Start(
+            rhinoExe,
+            "/nosplash /runscript=\"_StartMCP\"",
+            new Dictionary<string, string> { [PortEnvVar] = port.ToString() });
     }
 
     // Launches Rhino.app via `open -a`. We don't get a usable Process handle back —
@@ -526,15 +541,23 @@ public class RhinoManager(
         return 0;
     }
 
-    private static bool WaitForPort(int port, TimeSpan timeout)
+    private enum WaitResult { Bound, ProcessDied, Timeout }
+
+    // Wait until `port` is accepting connections. When `proc` is supplied we
+    // also short-circuit on process exit so the caller can distinguish a crash
+    // from a slow startup — the Mac path doesn't have a Process handle (we use
+    // `open -a` and resolve the pid via lsof after bind), so it passes null and
+    // only sees Bound/Timeout.
+    private static WaitResult WaitForPort(int port, TimeSpan timeout, Process? proc = null)
     {
         var deadline = DateTime.UtcNow + timeout;
         while (DateTime.UtcNow < deadline)
         {
-            if (IsPortListening(port)) return true;
+            if (IsPortListening(port)) return WaitResult.Bound;
+            if (proc is not null && proc.HasExited) return WaitResult.ProcessDied;
             Thread.Sleep(500);
         }
-        return false;
+        return WaitResult.Timeout;
     }
 
     private static bool IsPortListening(int port)

--- a/rhino/router/Router.csproj
+++ b/rhino/router/Router.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.2.0</Version>
+    <Version>0.1.0</Version>
     <Title>Rhino MCP Router</Title>
     <Company>McNeel</Company>
     <Description>Stdio MCP router that proxies tool calls to one or more Rhino MCP plugin instances. Spawns and manages child Rhinos so Claude Code only ever talks to one stable endpoint.</Description>

--- a/rhino/router/Router.csproj
+++ b/rhino/router/Router.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>0.1.0</Version>
+    <Version>0.2.0</Version>
     <Title>Rhino MCP Router</Title>
     <Company>McNeel</Company>
     <Description>Stdio MCP router that proxies tool calls to one or more Rhino MCP plugin instances. Spawns and manages child Rhinos so Claude Code only ever talks to one stable endpoint.</Description>
@@ -59,6 +59,7 @@
          so router and plugin agree at runtime. The 0.4.x preview line targets .NET 10
          packages and won't load under a net8.0 runtime. -->
     <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
   </ItemGroup>
 
   <!--
@@ -76,5 +77,21 @@
     <AdditionalFiles Include="../plugin/Tools/**/*.cs" />
     <AdditionalFiles Remove="../plugin/Tools/GH2/**/*.cs" Condition="'$(RhinoTarget)' == 'R8'" />
   </ItemGroup>
+
+  <!--
+    AOT publish drops native deps like libe_sqlite3.dylib in $(OutDir), but the
+    AOT-linked binary lives in $(OutDir)native/. dlopen searches alongside the
+    binary, so without this copy the router crashes on startup with a
+    DllNotFoundException for e_sqlite3. The publish dir gets it right out of
+    the box; this target makes the `dotnet build -r <rid>` flow work too, so
+    MCP clients can point at bin/.../native/rhino-mcp-router during dev.
+  -->
+  <Target Name="CopyNativeSqliteAlongsideAotBinary"
+          AfterTargets="Build"
+          Condition="'$(PublishAot)' == 'true' AND Exists('$(OutDir)libe_sqlite3.dylib')">
+    <Copy SourceFiles="$(OutDir)libe_sqlite3.dylib"
+          DestinationFolder="$(OutDir)native"
+          SkipUnchangedFiles="true" />
+  </Target>
 
 </Project>

--- a/rhino/router/Router.csproj
+++ b/rhino/router/Router.csproj
@@ -37,6 +37,12 @@
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugType>none</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <NativeDebugSymbols>false</NativeDebugSymbols>
+  </PropertyGroup>
+
   <!-- codegen/ holds the nested Router.Codegen project; exclude its sources from
        the router's default **/*.cs glob so they only compile in that project. -->
   <ItemGroup>

--- a/rhino/router/Router.csproj
+++ b/rhino/router/Router.csproj
@@ -10,6 +10,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
     <RhinoTarget Condition="'$(RhinoTarget)' == ''">R9</RhinoTarget>
+    <BaseOutputPath>$(MSBuildProjectDirectory)/bin/$(RhinoTarget)/</BaseOutputPath>
+    <BaseIntermediateOutputPath>$(MSBuildProjectDirectory)/obj/$(RhinoTarget)/</BaseIntermediateOutputPath>
+    <DefaultItemExcludes>$(DefaultItemExcludes);$(MSBuildProjectDirectory)/obj/**</DefaultItemExcludes>
   </PropertyGroup>
 
   <!--

--- a/rhino/router/Router.csproj
+++ b/rhino/router/Router.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RuntimeIdentifiers>win-x64;osx-arm64</RuntimeIdentifiers>
+    <RhinoTarget Condition="'$(RhinoTarget)' == ''">R9</RhinoTarget>
   </PropertyGroup>
 
   <!--
@@ -71,9 +72,9 @@
                       ReferenceOutputAssembly="false" />
   </ItemGroup>
 
-  <!-- Plugin tool sources, made visible to the generator as raw text. -->
   <ItemGroup>
     <AdditionalFiles Include="../plugin/Tools/**/*.cs" />
+    <AdditionalFiles Remove="../plugin/Tools/GH2/**/*.cs" Condition="'$(RhinoTarget)' == 'R8'" />
   </ItemGroup>
 
 </Project>

--- a/rhino/router/RouterPaths.cs
+++ b/rhino/router/RouterPaths.cs
@@ -1,0 +1,22 @@
+namespace RhMcp.Router;
+
+// Single source of truth for on-disk paths the router shares with the plugin.
+// All router state lives under <temp>/rhino-mcp/: state.db (slot registry) and
+// listeners/*.json (plugin->router doorbell announcements). The plugin writes
+// into the listeners dir; the router consumes from it.
+public static class RouterPaths
+{
+    public const string BaseDirName = "rhino-mcp";
+    public const string ListenersDirName = "listeners";
+    public const string StateDbName = "state.db";
+
+    public static string BaseDir => Path.Combine(Path.GetTempPath(), BaseDirName);
+    public static string ListenersDir => Path.Combine(BaseDir, ListenersDirName);
+    public static string StateDbPath => Path.Combine(BaseDir, StateDbName);
+
+    public static void EnsureDirectories()
+    {
+        Directory.CreateDirectory(BaseDir);
+        Directory.CreateDirectory(ListenersDir);
+    }
+}

--- a/rhino/router/SlotStore.cs
+++ b/rhino/router/SlotStore.cs
@@ -22,7 +22,7 @@ namespace RhMcp.Router;
 // is ephemeral runtime registry — wiping is correct on router upgrade.
 public sealed class SlotStore : IDisposable
 {
-    private const string CurrentRouterVersion = "0.2.0";
+    private const string CurrentRouterVersion = "0.1.0";
 
     private readonly SqliteConnection _conn;
     private readonly ILogger<SlotStore> _log;

--- a/rhino/router/SlotStore.cs
+++ b/rhino/router/SlotStore.cs
@@ -1,0 +1,484 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace RhMcp.Router;
+
+// Cross-process slot registry backed by SQLite. Replaces the in-memory
+// _children dict + _defaultGate/_macSpawnGate semaphores in earlier RhinoManager
+// versions, so concurrent routers (one per Claude Code session) can't race on
+// port allocation or duplicate-spawn the same per-version lead Rhino on Mac.
+//
+// Coordination contract:
+//   - All write paths take BEGIN IMMEDIATE so a second router serialises behind
+//     the first before deciding whether a slot already exists.
+//   - The slot row itself IS the lock: status='launching' is a placeholder a
+//     concurrent router observes and waits on; status='ready' is the live row.
+//   - Liveness (pid alive + port listening) is NOT stored — it's probed by
+//     RhinoManager. The DB only persists intent, never asserted health. Dead
+//     rows get DELETEd by reapers; we never write status='dead'.
+//
+// On schema/version mismatch we drop the slots table and rebuild. Slot state
+// is ephemeral runtime registry — wiping is correct on router upgrade.
+public sealed class SlotStore : IDisposable
+{
+    private const string CurrentRouterVersion = "0.2.0";
+
+    private readonly SqliteConnection _conn;
+    private readonly ILogger<SlotStore> _log;
+    private readonly object _connLock = new();
+
+    public SlotStore(ILogger<SlotStore> log)
+        : this(RouterPaths.StateDbPath, log) { }
+
+    public SlotStore(string dbPath, ILogger<SlotStore> log)
+    {
+        _log = log;
+        RouterPaths.EnsureDirectories();
+
+        // Cache=Shared lets multiple connections within this process share a
+        // page cache; multi-process concurrency comes from WAL + busy_timeout.
+        var cs = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            Cache = SqliteCacheMode.Shared,
+            Pooling = false,
+        }.ToString();
+
+        _conn = new SqliteConnection(cs);
+        _conn.Open();
+
+        // WAL gives readers + writers concurrency; busy_timeout makes the
+        // driver auto-retry on SQLITE_BUSY for up to 5s before throwing.
+        Exec("PRAGMA journal_mode=WAL;");
+        Exec("PRAGMA synchronous=NORMAL;");
+        Exec("PRAGMA busy_timeout=5000;");
+
+        EnsureSchema();
+    }
+
+    private void EnsureSchema()
+    {
+        // meta is the version marker. If the stored version doesn't match the
+        // router we're running, drop the slots table (it's runtime state, never
+        // user data) and stamp the new version. Migrations are explicitly out
+        // of scope — see commit that introduced this for rationale.
+        Exec(@"CREATE TABLE IF NOT EXISTS meta (
+                 key   TEXT PRIMARY KEY,
+                 value TEXT NOT NULL);");
+
+        var stored = Scalar("SELECT value FROM meta WHERE key='router_version';");
+        if (stored != CurrentRouterVersion)
+        {
+            if (stored is not null)
+            {
+                _log.LogInformation("SlotStore: router version changed ({Old} -> {New}); wiping slot table.",
+                    stored, CurrentRouterVersion);
+            }
+            Exec("DROP TABLE IF EXISTS slots;");
+            Exec("DELETE FROM meta;");
+        }
+
+        // started_at unix-ms drives stale-launching reaping. router_pid lets a
+        // router differentiate slots it owns from slots owned by a peer router
+        // (used during shutdown — we kill only our own ready rows).
+        Exec(@"CREATE TABLE IF NOT EXISTS slots (
+                 slot_id     TEXT PRIMARY KEY,
+                 version     TEXT NOT NULL,
+                 port        INTEGER,
+                 pid         INTEGER,
+                 status      TEXT NOT NULL,
+                 adopted     INTEGER NOT NULL,
+                 started_at  INTEGER NOT NULL,
+                 router_pid  INTEGER NOT NULL);");
+        Exec("CREATE INDEX IF NOT EXISTS idx_slots_version_status ON slots(version, status);");
+        Exec("CREATE INDEX IF NOT EXISTS idx_slots_pid            ON slots(pid);");
+
+        // Animal-name pool lives in the DB so name allocation is cross-process
+        // serialisable: picking happens inside the same transaction as the slot
+        // INSERT, so two routers can't both grab 'armadillo'. Names "recycle"
+        // implicitly — a name is taken iff a slot row uses it as slot_id, so
+        // deletion frees it. Idx is just the seed order; first-fit favors the
+        // earliest unclaimed entry, which makes test output deterministic.
+        Exec(@"CREATE TABLE IF NOT EXISTS name_pool (
+                 idx  INTEGER PRIMARY KEY,
+                 name TEXT UNIQUE NOT NULL);");
+
+        SeedNamePool();
+
+        Exec("INSERT OR REPLACE INTO meta(key,value) VALUES('router_version', $v);",
+             ("$v", CurrentRouterVersion));
+    }
+
+    private void SeedNamePool()
+    {
+        // INSERT OR IGNORE makes seeding idempotent across router restarts. The
+        // pool ordering is fixed at first-seed; subsequent additions append at
+        // a higher idx and only appear after the existing pool is exhausted.
+        for (int i = 0; i < AnimalNames.Pool.Length; i++)
+        {
+            Exec("INSERT OR IGNORE INTO name_pool(idx, name) VALUES($i, $n);",
+                 ("$i", i), ("$n", AnimalNames.Pool[i]));
+        }
+    }
+
+    // Atomic "is this slot taken, or can I claim it?" The returned reservation
+    // tells the caller which of three branches to follow:
+    //   Existing  — slot row was already there; caller waits/uses as-is.
+    //   Leader    — placeholder inserted AND no other row for this version
+    //               existed; caller does the full Rhino launch (Windows: always;
+    //               Mac: launches Rhino.app).
+    //   Follower  — placeholder inserted but another row for this version is
+    //               present; caller waits for that row to become ready and
+    //               then calls _router_spawn_listener against it. Mac-only path.
+    //
+    // The leader/follower decision happens INSIDE the BEGIN IMMEDIATE, so two
+    // concurrent reservations can't both decide they're the leader.
+    public SlotReservation Reserve(string slotId, string version, int routerPid)
+    {
+        lock (_connLock)
+        {
+            using var tx = _conn.BeginTransaction(deferred: false); // BEGIN IMMEDIATE
+
+            var existing = QueryOne(tx, "SELECT * FROM slots WHERE slot_id=$s;", ("$s", slotId));
+            if (existing is not null)
+            {
+                tx.Commit();
+                return SlotReservation.Existing(existing);
+            }
+
+            var hasPeerForVersion = ScalarLong(tx,
+                "SELECT COUNT(*) FROM slots WHERE version=$v AND slot_id != $s;",
+                ("$v", version), ("$s", slotId)) > 0;
+
+            Exec(tx, @"INSERT INTO slots(slot_id, version, status, adopted, started_at, router_pid)
+                       VALUES($s, $v, 'launching', 0, $t, $r);",
+                 ("$s", slotId), ("$v", version),
+                 ("$t", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
+                 ("$r", routerPid));
+
+            tx.Commit();
+
+            return hasPeerForVersion
+                ? SlotReservation.Follower(slotId, version)
+                : SlotReservation.Leader(slotId, version);
+        }
+    }
+
+    // Pick an unused animal name AND insert the placeholder in one transaction
+    // so concurrent routers can't both claim the same name. Falls back to
+    // 'slot-N' (N = max numeric suffix of existing slot-N ids, + 1) when the
+    // pool is exhausted. Returns the chosen slot_id alongside the reservation.
+    public (SlotReservation reservation, string slotId) ReserveNewNamed(string version, int routerPid)
+    {
+        lock (_connLock)
+        {
+            using var tx = _conn.BeginTransaction(deferred: false);
+
+            string? picked;
+            using (var cmd = _conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = @"SELECT name FROM name_pool
+                                    WHERE name NOT IN (SELECT slot_id FROM slots)
+                                    ORDER BY idx ASC LIMIT 1;";
+                picked = cmd.ExecuteScalar() as string;
+            }
+
+            string slotId = picked ?? FallbackNumberedSlot(tx);
+
+            var hasPeerForVersion = ScalarLong(tx,
+                "SELECT COUNT(*) FROM slots WHERE version=$v;",
+                ("$v", version)) > 0;
+
+            Exec(tx, @"INSERT INTO slots(slot_id, version, status, adopted, started_at, router_pid)
+                       VALUES($s, $v, 'launching', 0, $t, $r);",
+                 ("$s", slotId), ("$v", version),
+                 ("$t", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
+                 ("$r", routerPid));
+
+            tx.Commit();
+
+            var reservation = hasPeerForVersion
+                ? SlotReservation.Follower(slotId, version)
+                : SlotReservation.Leader(slotId, version);
+            return (reservation, slotId);
+        }
+    }
+
+    // Caller already holds the immediate transaction. Walks slot_ids matching
+    // 'slot-<n>' and returns one greater than the highest n seen. No regex in
+    // SQLite-stock; we scan in C# because the pool is tiny.
+    private string FallbackNumberedSlot(SqliteTransaction tx)
+    {
+        int max = 0;
+        using var cmd = _conn.CreateCommand();
+        cmd.Transaction = tx;
+        cmd.CommandText = "SELECT slot_id FROM slots WHERE slot_id LIKE 'slot-%';";
+        using var r = cmd.ExecuteReader();
+        while (r.Read())
+        {
+            var id = r.GetString(0);
+            if (int.TryParse(id.AsSpan("slot-".Length), out var n) && n > max) max = n;
+        }
+        return $"slot-{max + 1}";
+    }
+
+    // Pick a free port AND record it on our placeholder in one transaction so
+    // concurrent routers can't both choose the same port. Caller passes a
+    // probe that confirms the OS isn't listening on the candidate; this method
+    // only excludes ports already claimed in the DB.
+    public int ReservePort(string slotId, int basePort, Func<int, bool> isPortListening)
+    {
+        lock (_connLock)
+        {
+            using var tx = _conn.BeginTransaction(deferred: false);
+
+            var taken = new HashSet<int>();
+            using (var cmd = _conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = "SELECT port FROM slots WHERE port IS NOT NULL;";
+                using var r = cmd.ExecuteReader();
+                while (r.Read()) taken.Add(r.GetInt32(0));
+            }
+
+            for (int p = basePort; p < 65000; p++)
+            {
+                if (taken.Contains(p)) continue;
+                if (isPortListening(p)) continue;
+                Exec(tx, "UPDATE slots SET port=$p WHERE slot_id=$s;", ("$p", p), ("$s", slotId));
+                tx.Commit();
+                return p;
+            }
+
+            tx.Rollback();
+            throw new InvalidOperationException("No free ports available in spawn range.");
+        }
+    }
+
+    public ChildRhino? WaitForReady(string slotId, TimeSpan timeout, CancellationToken ct = default)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            ct.ThrowIfCancellationRequested();
+            var row = Get(slotId);
+            if (row is null) return null;
+            if (row.Status == SlotStatus.Ready) return row;
+            Thread.Sleep(200);
+        }
+        return null;
+    }
+
+    public ChildRhino? FindReadyLead(string version, string excludingSlotId)
+    {
+        lock (_connLock)
+        {
+            return QueryOne(null,
+                "SELECT * FROM slots WHERE version=$v AND status='ready' AND slot_id != $s ORDER BY started_at ASC LIMIT 1;",
+                ("$v", version), ("$s", excludingSlotId));
+        }
+    }
+
+    public void MarkReady(string slotId, int port, int pid)
+    {
+        lock (_connLock)
+        {
+            Exec("UPDATE slots SET status='ready', port=$p, pid=$pid WHERE slot_id=$s;",
+                 ("$p", port), ("$pid", pid), ("$s", slotId));
+        }
+    }
+
+    public void Delete(string slotId)
+    {
+        lock (_connLock)
+        {
+            Exec("DELETE FROM slots WHERE slot_id=$s;", ("$s", slotId));
+        }
+    }
+
+    // Drop-file adoption. Atomically:
+    //   1. Bail out (return null) if any slot already points at this (pid, port)
+    //      — guards against duplicate announcements for a single listener.
+    //   2. Pick the first unused name from name_pool, or fall back to 'slot-N'.
+    //   3. Insert the adopted+ready row.
+    // The whole thing runs under BEGIN IMMEDIATE so a peer router can't race us
+    // into picking the same name or adopting the same listener twice.
+    public string? AdoptIfNew(string version, int port, int pid, int routerPid)
+    {
+        lock (_connLock)
+        {
+            using var tx = _conn.BeginTransaction(deferred: false);
+
+            var dup = ScalarLong(tx,
+                "SELECT COUNT(*) FROM slots WHERE pid=$p AND port=$port;",
+                ("$p", pid), ("$port", port)) > 0;
+            if (dup) { tx.Commit(); return null; }
+
+            string? picked;
+            using (var cmd = _conn.CreateCommand())
+            {
+                cmd.Transaction = tx;
+                cmd.CommandText = @"SELECT name FROM name_pool
+                                    WHERE name NOT IN (SELECT slot_id FROM slots)
+                                    ORDER BY idx ASC LIMIT 1;";
+                picked = cmd.ExecuteScalar() as string;
+            }
+            string slotId = picked ?? FallbackNumberedSlot(tx);
+
+            Exec(tx, @"INSERT INTO slots(slot_id, version, port, pid, status, adopted, started_at, router_pid)
+                       VALUES($s, $v, $p, $pid, 'ready', 1, $t, $r);",
+                 ("$s", slotId), ("$v", version), ("$p", port), ("$pid", pid),
+                 ("$t", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()),
+                 ("$r", routerPid));
+
+            tx.Commit();
+            return slotId;
+        }
+    }
+
+    public ChildRhino? Get(string slotId)
+    {
+        lock (_connLock)
+        {
+            return QueryOne(null, "SELECT * FROM slots WHERE slot_id=$s;", ("$s", slotId));
+        }
+    }
+
+    public IReadOnlyList<ChildRhino> ListReady()
+    {
+        lock (_connLock)
+        {
+            return Query(null, "SELECT * FROM slots WHERE status='ready';");
+        }
+    }
+
+    public IReadOnlyList<ChildRhino> ListAllOwnedBy(int routerPid)
+    {
+        lock (_connLock)
+        {
+            return Query(null, "SELECT * FROM slots WHERE router_pid=$r;", ("$r", routerPid));
+        }
+    }
+
+    // Mac shared-pid: find any other ready slot pointing at the same Rhino
+    // process. If one exists, this isn't the last listener and CloseAsync
+    // should tear down just the listener via the control channel, not the pid.
+    public ChildRhino? FindSiblingByPid(string slotId, int pid)
+    {
+        lock (_connLock)
+        {
+            return QueryOne(null,
+                "SELECT * FROM slots WHERE pid=$p AND slot_id != $s AND status='ready' LIMIT 1;",
+                ("$p", pid), ("$s", slotId));
+        }
+    }
+
+    // Crashed-router cleanup. A router that died between Reserve() and
+    // MarkReady() leaves a 'launching' row behind; any router (typically the
+    // next one to try to spawn) deletes them once they exceed maxAge.
+    public int ReapStaleLaunching(TimeSpan maxAge)
+    {
+        lock (_connLock)
+        {
+            var cutoff = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - (long)maxAge.TotalMilliseconds;
+            return Exec("DELETE FROM slots WHERE status='launching' AND started_at < $c;", ("$c", cutoff));
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _conn.Close(); } catch { }
+        _conn.Dispose();
+    }
+
+    // ----- helpers -----------------------------------------------------------
+
+    private int Exec(string sql, params (string, object)[] args) => Exec(null, sql, args);
+
+    private int Exec(SqliteTransaction? tx, string sql, params (string, object)[] args)
+    {
+        using var cmd = _conn.CreateCommand();
+        if (tx is not null) cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var (k, v) in args) cmd.Parameters.AddWithValue(k, v);
+        return cmd.ExecuteNonQuery();
+    }
+
+    private string? Scalar(string sql, params (string, object)[] args)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = sql;
+        foreach (var (k, v) in args) cmd.Parameters.AddWithValue(k, v);
+        return cmd.ExecuteScalar() as string;
+    }
+
+    private long ScalarLong(SqliteTransaction? tx, string sql, params (string, object)[] args)
+    {
+        using var cmd = _conn.CreateCommand();
+        if (tx is not null) cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var (k, v) in args) cmd.Parameters.AddWithValue(k, v);
+        var v2 = cmd.ExecuteScalar();
+        return v2 is long l ? l : Convert.ToInt64(v2);
+    }
+
+    private ChildRhino? QueryOne(SqliteTransaction? tx, string sql, params (string, object)[] args)
+    {
+        using var cmd = _conn.CreateCommand();
+        if (tx is not null) cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var (k, v) in args) cmd.Parameters.AddWithValue(k, v);
+        using var r = cmd.ExecuteReader();
+        return r.Read() ? ReadRow(r) : null;
+    }
+
+    private IReadOnlyList<ChildRhino> Query(SqliteTransaction? tx, string sql, params (string, object)[] args)
+    {
+        var result = new List<ChildRhino>();
+        using var cmd = _conn.CreateCommand();
+        if (tx is not null) cmd.Transaction = tx;
+        cmd.CommandText = sql;
+        foreach (var (k, v) in args) cmd.Parameters.AddWithValue(k, v);
+        using var r = cmd.ExecuteReader();
+        while (r.Read()) result.Add(ReadRow(r));
+        return result;
+    }
+
+    private static ChildRhino ReadRow(IDataReader r) => new(
+        SlotId: r.GetString(r.GetOrdinal("slot_id")),
+        Port:   r.IsDBNull(r.GetOrdinal("port")) ? 0 : r.GetInt32(r.GetOrdinal("port")),
+        Pid:    r.IsDBNull(r.GetOrdinal("pid")) ? 0 : r.GetInt32(r.GetOrdinal("pid")),
+        Version: r.GetString(r.GetOrdinal("version")),
+        Adopted: r.GetInt32(r.GetOrdinal("adopted")) != 0,
+        Status:  r.GetString(r.GetOrdinal("status")));
+}
+
+public static class SlotStatus
+{
+    public const string Launching = "launching";
+    public const string Ready     = "ready";
+}
+
+// Tagged union shape via static factories. Concrete callsite branches on Kind.
+// Property names deliberately don't match the factory names — a record's
+// positional parameter becomes a same-named property, which would clash with
+// the static method group otherwise.
+public sealed record SlotReservation(
+    SlotReservation.ReservationKind Kind,
+    ChildRhino? ExistingSlot,
+    string? SlotId,
+    string? Version)
+{
+    public enum ReservationKind { Existing, Leader, Follower }
+
+    public static SlotReservation Existing(ChildRhino slot) =>
+        new(ReservationKind.Existing, slot, null, null);
+
+    public static SlotReservation Leader(string slotId, string version) =>
+        new(ReservationKind.Leader, null, slotId, version);
+
+    public static SlotReservation Follower(string slotId, string version) =>
+        new(ReservationKind.Follower, null, slotId, version);
+}

--- a/rhino/router/WinSpawn.cs
+++ b/rhino/router/WinSpawn.cs
@@ -1,0 +1,120 @@
+using System.Collections;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace RhMcp.Router;
+
+// Launches a Windows child via CreateProcess with CREATE_BREAKAWAY_FROM_JOB so
+// it escapes any Job Object the router inherited from its parent (e.g. the
+// Claude Code / VS Code extension host that spawned node -> the router).
+// Without breakaway, GUI children can come up alive but with no interactive
+// desktop and never paint a main window — see RhinoManager.LaunchAsLeaderAsync's
+// "never created a main window" diagnostic.
+//
+// We don't use Process.Start with UseShellExecute=true (which would also fix
+// the window problem) because ShellExecute silently ignores psi.Environment.
+// Going through CreateProcess keeps the env block per-child, so concurrent
+// spawns don't race on RHINO_MCP_AUTOSTART_PORT.
+internal static class WinSpawn
+{
+    private const uint CREATE_BREAKAWAY_FROM_JOB  = 0x01000000;
+    private const uint CREATE_UNICODE_ENVIRONMENT = 0x00000400;
+
+    public static Process Start(string exePath, string arguments, IDictionary<string, string> extraEnv)
+    {
+        // CreateProcess can write into lpCommandLine; hand it a pre-sized buffer.
+        // 32k matches Windows' command-line limit.
+        var cmdLine = new StringBuilder(32768);
+        cmdLine.Append('"').Append(exePath).Append('"').Append(' ').Append(arguments);
+
+        var startup = new STARTUPINFOW { cb = (uint)Marshal.SizeOf<STARTUPINFOW>() };
+        IntPtr envBlock = BuildEnvBlock(extraEnv);
+        try
+        {
+            if (!CreateProcessW(
+                lpApplicationName: null,
+                lpCommandLine: cmdLine,
+                lpProcessAttributes: IntPtr.Zero,
+                lpThreadAttributes: IntPtr.Zero,
+                bInheritHandles: false,
+                dwCreationFlags: CREATE_BREAKAWAY_FROM_JOB | CREATE_UNICODE_ENVIRONMENT,
+                lpEnvironment: envBlock,
+                lpCurrentDirectory: null,
+                lpStartupInfo: ref startup,
+                lpProcessInformation: out PROCESS_INFORMATION pi))
+            {
+                int err = Marshal.GetLastWin32Error();
+                throw new Win32Exception(err,
+                    $"CreateProcess failed for '{exePath}' (error {err}). " +
+                    $"If access-denied, the router's parent Job Object disallows breakaway.");
+            }
+
+            CloseHandle(pi.hThread);
+            try { return Process.GetProcessById((int)pi.dwProcessId); }
+            finally { CloseHandle(pi.hProcess); }
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(envBlock);
+        }
+    }
+
+    // UTF-16 env block: KEY1=val1\0KEY2=val2\0\0. Windows env-var lookup is
+    // case-insensitive, and the block must be sorted in case-insensitive
+    // ordinal order or some apps misbehave.
+    private static IntPtr BuildEnvBlock(IDictionary<string, string> overrides)
+    {
+        var merged = new SortedDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry e in Environment.GetEnvironmentVariables())
+            merged[(string)e.Key] = (string)(e.Value ?? "");
+        foreach (var kv in overrides)
+            merged[kv.Key] = kv.Value;
+
+        var sb = new StringBuilder();
+        foreach (var kv in merged)
+            sb.Append(kv.Key).Append('=').Append(kv.Value).Append('\0');
+        sb.Append('\0');
+        return Marshal.StringToHGlobalUni(sb.ToString());
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct STARTUPINFOW
+    {
+        public uint cb;
+        public IntPtr lpReserved;
+        public IntPtr lpDesktop;
+        public IntPtr lpTitle;
+        public uint dwX, dwY, dwXSize, dwYSize, dwXCountChars, dwYCountChars, dwFillAttribute, dwFlags;
+        public ushort wShowWindow, cbReserved2;
+        public IntPtr lpReserved2, hStdInput, hStdOutput, hStdError;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct PROCESS_INFORMATION
+    {
+        public IntPtr hProcess;
+        public IntPtr hThread;
+        public uint dwProcessId;
+        public uint dwThreadId;
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CreateProcessW(
+        string? lpApplicationName,
+        StringBuilder lpCommandLine,
+        IntPtr lpProcessAttributes,
+        IntPtr lpThreadAttributes,
+        [MarshalAs(UnmanagedType.Bool)] bool bInheritHandles,
+        uint dwCreationFlags,
+        IntPtr lpEnvironment,
+        string? lpCurrentDirectory,
+        ref STARTUPINFOW lpStartupInfo,
+        out PROCESS_INFORMATION lpProcessInformation);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CloseHandle(IntPtr hObject);
+}

--- a/rhino/router/codegen/RouterToolGenerator.cs
+++ b/rhino/router/codegen/RouterToolGenerator.cs
@@ -202,7 +202,17 @@ public class RouterToolGenerator : IIncrementalGenerator
                 sb.AppendLine($"        args[\"{p.Name}\"] = global::System.Text.Json.Nodes.JsonValue.Create({p.Name});");
             }
         }
-        sb.AppendLine($"        return proxy.CallToolAsync(slot, \"{tool.Name}\", args, ct);");
+        // GH2_* tools only work in Rhino WIP (Grasshopper 2 only ships there),
+        // so when no slot is passed the router auto-spawns WIP instead of the
+        // configured default. Non-GH2 tools pass null and use the configured default.
+        if (tool.ClassName.StartsWith("GH2_"))
+        {
+            sb.AppendLine($"        return proxy.CallToolAsync(slot, \"{tool.Name}\", args, ct, defaultVersionOverride: \"WIP\");");
+        }
+        else
+        {
+            sb.AppendLine($"        return proxy.CallToolAsync(slot, \"{tool.Name}\", args, ct);");
+        }
 
         sb.AppendLine("    }");
         sb.AppendLine("}");

--- a/shared/router-launcher.mjs
+++ b/shared/router-launcher.mjs
@@ -42,7 +42,7 @@ function findRouter() {
 
   const exe = process.platform === "win32" ? "rhino-mcp-router.exe" : "rhino-mcp-router";
 
-  // Numeric-aware reverse sort: 0.10.0 ranks above 0.2.0 (lexical would invert).
+  // Numeric-aware reverse sort: 0.10.0 ranks above 0.1.0 (lexical would invert).
   const byVersionDesc = (a, b) => b.localeCompare(a, undefined, { numeric: true });
 
   const considered = [];

--- a/tests/launcher/launcher.test.mjs
+++ b/tests/launcher/launcher.test.mjs
@@ -120,16 +120,16 @@ test("linux reports unsupported platform and exits 1", { skip: isSupported }, ()
 
 test("picks newest pkg-ver under one Rhino major", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.1.0": { binary: "exec" }, "0.2.0": { binary: "exec" } },
+    "9.0": { "0.1.0": { binary: "exec" }, "0.1.0": { binary: "exec" } },
   });
   const r = runLauncher(fake.env, ["-e", "process.exit(0)"]);
   assert.equal(r.status, 0);
   assert.match(r.stderr, /9\.0\/0\.2\.0\*/);
 });
 
-test("numeric semver: 0.10.0 ranks above 0.2.0", { skip: !isSupported }, () => {
+test("numeric semver: 0.10.0 ranks above 0.1.0", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.2.0": { binary: "exec" }, "0.10.0": { binary: "exec" } },
+    "9.0": { "0.1.0": { binary: "exec" }, "0.10.0": { binary: "exec" } },
   });
   const r = runLauncher(fake.env, ["-e", "process.exit(0)"]);
   assert.equal(r.status, 0);
@@ -168,7 +168,7 @@ test("no yak installed → enters install-fallback (exit 0 on stdin EOF)", { ski
 
 test("yak exists but no router binary for this rid → enters install-fallback", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.2.0": { binary: null } },
+    "9.0": { "0.1.0": { binary: null } },
   });
   const r = runLauncher({ ...fake.env, ...FAKE_YAK_INSTALLED });
   assert.equal(r.status, 0);
@@ -187,7 +187,7 @@ test("no yak AND Rhino not installed → enters rhino-missing-fallback", { skip:
 
 test("non-executable binary at picked path → exit 1, not exit 0", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.2.0": { binary: "nonexec" } },
+    "9.0": { "0.1.0": { binary: "nonexec" } },
   });
   const r = runLauncher(fake.env);
   // Was the original bug: error+close both fired and process.exit(code ?? 0)
@@ -198,7 +198,7 @@ test("non-executable binary at picked path → exit 1, not exit 0", { skip: !isS
 
 test("successful child exit (code 0) propagates", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.2.0": { binary: "exec" } },
+    "9.0": { "0.1.0": { binary: "exec" } },
   });
   const r = runLauncher(fake.env, ["-e", "process.exit(0)"]);
   assert.equal(r.status, 0);
@@ -206,7 +206,7 @@ test("successful child exit (code 0) propagates", { skip: !isSupported }, () => 
 
 test("non-zero child exit code propagates verbatim", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.2.0": { binary: "exec" } },
+    "9.0": { "0.1.0": { binary: "exec" } },
   });
   const r = runLauncher(fake.env, ["-e", "process.exit(42)"]);
   assert.equal(r.status, 42);
@@ -339,7 +339,7 @@ test("fallback: no yak → initialize advertises rhino-mcp-installer", { skip: !
 });
 
 test("fallback: yak-but-no-binary path also enters fallback (different reason)", { skip: !isSupported }, async () => {
-  const fake = makeFakeRoot({ "9.0": { "0.2.0": { binary: null } } });
+  const fake = makeFakeRoot({ "9.0": { "0.1.0": { binary: null } } });
   const l = startFallbackLauncher({ ...fake.env, ...FAKE_YAK_INSTALLED });
   try {
     const r = await l.request("initialize", { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "t", version: "0" } }, 0);

--- a/tests/launcher/launcher.test.mjs
+++ b/tests/launcher/launcher.test.mjs
@@ -120,11 +120,11 @@ test("linux reports unsupported platform and exits 1", { skip: isSupported }, ()
 
 test("picks newest pkg-ver under one Rhino major", { skip: !isSupported }, () => {
   const fake = makeFakeRoot({
-    "9.0": { "0.1.0": { binary: "exec" }, "0.1.0": { binary: "exec" } },
+    "9.0": { "0.0.1": { binary: "exec" }, "0.1.0": { binary: "exec" } },
   });
   const r = runLauncher(fake.env, ["-e", "process.exit(0)"]);
   assert.equal(r.status, 0);
-  assert.match(r.stderr, /9\.0\/0\.2\.0\*/);
+  assert.match(r.stderr, /9\.0\/0\.1\.0\*/);
 });
 
 test("numeric semver: 0.10.0 ranks above 0.1.0", { skip: !isSupported }, () => {


### PR DESCRIPTION
This PR got enjoyably out of hand with all the various paper-cuts and bugs I found.

- Updated the MCP Server to offer GH2 Functionality in parity with GH1
- Added conditional split between R8/9 to handle this so there is an R8/R9 specific yak.
- The Router handles routing GH2 requests to 9/WIP instead of 8
- Ensure the Router can handle multiple AI agents talking to it.
- Wrap ALL commands in a UI thread by default
- Ensure ALL commands use the injected RhinoDoc, and improve scripts to use `__rhino_doc__`
- SLNX fies
- New Open/Close/Save doc tools