### PR TITLE
Ensure that any existing Rhino can be adopted

### DIFF
--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.IO;
+
 namespace RhMcp;
 
 public static class RhinoMcpHost
@@ -30,7 +33,9 @@ public static class RhinoMcpHost
         McpServer server = new();
         Servers.Add(doc.RuntimeSerialNumber, server);
 
-        return server.Start(doc, port);
+        var ok = server.Start(doc, port);
+        if (ok) WriteAnnouncement(port);
+        return ok;
     }
 
     public static void Stop(RhinoDoc doc)
@@ -47,6 +52,32 @@ public static class RhinoMcpHost
         Stop(doc);
         Start(doc, port);
         return true;
+    }
+
+    // Drop a one-shot announcement into <temp>/rhino-mcp-listeners/ so a router
+    // running on this machine can discover and adopt this listener without us
+    // having to know whether one is up. The router consumes (probes + deletes)
+    // the file on its next scan; if no router ever sees it, temp sweep collects
+    // it eventually. See router's RhinoManager.ScanAnnouncements.
+    private static void WriteAnnouncement(int port)
+    {
+        try
+        {
+            var dir = Path.Combine(Path.GetTempPath(), "rhino-mcp-listeners");
+            Directory.CreateDirectory(dir);
+            var pid = Process.GetCurrentProcess().Id;
+            var version = RhinoApp.Version.Major.ToString();
+            var path = Path.Combine(dir, $"{pid}-{port}.json");
+            var tmp = path + ".tmp";
+            var json = JsonSerializer.Serialize(new { v = 1, pid, port, version });
+            File.WriteAllText(tmp, json);
+            if (File.Exists(path)) File.Delete(path);
+            File.Move(tmp, path);
+        }
+        catch (Exception ex)
+        {
+            RhinoApp.WriteLine($"[Rhino MCP] Failed to write listener announcement: {ex.Message}");
+        }
     }
 
     // Stop the listener bound to the given port, regardless of doc. Used by the

--- a/rhino/router/Program.cs
+++ b/rhino/router/Program.cs
@@ -43,6 +43,11 @@ RouterToolRegistrar.RegisterAll(mcpBuilder, jsonOptions);
 
 var host = builder.Build();
 
+// Adopt any user-started Rhinos that announced themselves before the router
+// came up. Cheap one-shot dir scan; later scans happen on every list_slots
+// and slot-less dispatch.
+host.Services.GetRequiredService<RhinoManager>().ScanAnnouncements();
+
 // Clean up child Rhinos when Claude Code closes the stdio connection.
 host.Services.GetRequiredService<IHostApplicationLifetime>().ApplicationStopping.Register(() =>
 {

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace RhMcp.Router;
@@ -49,8 +50,13 @@ public class RhinoManager(
 
     // Lazily return the default slot, spawning a Rhino for it if one doesn't already exist.
     // Called by ProxyDispatcher when a tool is invoked without an explicit slot.
+    // Adopted Rhinos are deliberately not promoted to the default slot — slot-less
+    // calls still spawn a fresh router-owned Rhino so the user's manually-started
+    // session isn't hijacked.
     public async Task<ChildRhino> GetOrCreateDefaultAsync(CancellationToken ct = default)
     {
+        ScanAnnouncements();
+
         lock (_lock)
         {
             if (_children.TryGetValue(DefaultSlotId, out var existing)) return existing;
@@ -169,6 +175,14 @@ public class RhinoManager(
             if (!_children.TryGetValue(slotId, out child)) return false;
         }
 
+        if (child.Adopted)
+        {
+            // The router didn't start this Rhino, so it doesn't get to kill the
+            // process. Tools layer turns this into a structured error so the
+            // agent learns why; here we just refuse.
+            throw new AdoptedSlotCloseException(slotId);
+        }
+
         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             // Find sibling slots sharing this pid. If any exist, this isn't the last
@@ -217,6 +231,8 @@ public class RhinoManager(
     {
         // Shutdown path: kill each unique pid once. No control-channel niceties —
         // we're tearing everything down anyway, and multiple slots may share a pid on Mac.
+        // Adopted slots are skipped: the user owns those Rhinos, so router shutdown
+        // must not take them down.
         string[] ids;
         lock (_lock) ids = _children.Keys.ToArray();
 
@@ -227,6 +243,7 @@ public class RhinoManager(
             lock (_lock)
             {
                 if (!_children.TryGetValue(id, out c)) continue;
+                if (c.Adopted) { _children.Remove(id); continue; }
                 _children.Remove(id);
             }
             if (!killed.Add(c.Pid)) continue;
@@ -250,6 +267,91 @@ public class RhinoManager(
     public ChildRhino? Get(string slotId)
     {
         lock (_lock) return _children.GetValueOrDefault(slotId);
+    }
+
+    // Walk the listener-announcement drop directory and adopt any plugin-side
+    // Rhino we don't already know about. The plugin writes one file per
+    // listener-bind into <temp>/rhino-mcp-listeners; we treat each file as a
+    // one-shot "look at me" doorbell — consume by deleting it whether or not
+    // adoption succeeded. Stale files (port no longer listening) are dropped
+    // silently; files for a pid+port we already track are deleted as a no-op so
+    // the Mac _router_spawn_listener path remains idempotent.
+    public void ScanAnnouncements()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "rhino-mcp-listeners");
+        if (!Directory.Exists(dir)) return;
+
+        string[] files;
+        try { files = Directory.GetFiles(dir, "*.json"); }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "Failed to enumerate listener-announcement dir {Dir}", dir);
+            return;
+        }
+
+        foreach (var file in files)
+        {
+            try
+            {
+                Announcement? ann;
+                try
+                {
+                    var json = File.ReadAllText(file);
+                    ann = JsonSerializer.Deserialize(json, RouterJsonContext.Default.Announcement);
+                }
+                catch (Exception ex)
+                {
+                    log.LogWarning(ex, "Bad announcement file {File}; deleting", file);
+                    TryDelete(file);
+                    continue;
+                }
+
+                if (ann is null || ann.Port <= 0 || ann.Pid <= 0)
+                {
+                    TryDelete(file);
+                    continue;
+                }
+
+                bool alreadyKnown;
+                lock (_lock)
+                {
+                    alreadyKnown = _children.Values.Any(c => c.Pid == ann.Pid && c.Port == ann.Port);
+                }
+
+                if (alreadyKnown)
+                {
+                    // Mac _router_spawn_listener case (and any other duplicate) —
+                    // file is harmless once consumed.
+                    TryDelete(file);
+                    continue;
+                }
+
+                if (!IsPortListening(ann.Port))
+                {
+                    log.LogDebug("Announcement for pid {Pid} port {Port} is stale (no listener); discarding",
+                        ann.Pid, ann.Port);
+                    TryDelete(file);
+                    continue;
+                }
+
+                var slotId = AnimalNames.Next();
+                var child = new ChildRhino(slotId, ann.Port, ann.Pid, ann.Version ?? "?", Adopted: true);
+                lock (_lock) _children[slotId] = child;
+                log.LogInformation("Adopted user-started Rhino {Version} as slot '{Slot}' (pid {Pid}, port {Port})",
+                    child.Version, slotId, ann.Pid, ann.Port);
+                TryDelete(file);
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(ex, "Unexpected failure processing announcement {File}", file);
+                TryDelete(file);
+            }
+        }
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { File.Delete(path); } catch { /* next scan will retry */ }
     }
 
     // Cheap liveness probe. Considers a slot alive iff its pid still exists AND
@@ -434,7 +536,21 @@ public class RhinoManager(
     }
 }
 
-public record ChildRhino(string SlotId, int Port, int Pid, string Version)
+// Thrown by CloseAsync when the caller tries to close an adopted slot. The
+// tools layer catches this and turns it into a structured `cannot_close_adopted`
+// payload — the agent learns why and we still avoid killing a user-started
+// Rhino.
+public sealed class AdoptedSlotCloseException(string slotId)
+    : InvalidOperationException($"Slot '{slotId}' was adopted from a user-started Rhino and cannot be closed by the router.")
+{
+    public string SlotId { get; } = slotId;
+}
+
+// `Adopted` is set when the router discovered this Rhino via a drop-file
+// announcement rather than spawning it. Adopted slots are never killed by the
+// router (CloseAll skips them; close_slot refuses) — the user started them, the
+// user closes them.
+public record ChildRhino(string SlotId, int Port, int Pid, string Version, bool Adopted = false)
 {
     public string Endpoint => $"http://localhost:{Port}";
 }

--- a/rhino/router/RouterJsonContext.cs
+++ b/rhino/router/RouterJsonContext.cs
@@ -21,6 +21,8 @@ namespace RhMcp.Router;
 [JsonSerializable(typeof(JsonRpcRequestParams))]
 [JsonSerializable(typeof(SpawnListenerArgs))]
 [JsonSerializable(typeof(CloseListenerArgs))]
+[JsonSerializable(typeof(Announcement))]
+[JsonSerializable(typeof(CloseSlotResult))]
 [JsonSerializable(typeof(JsonObject))]
 [JsonSerializable(typeof(JsonElement))]
 [JsonSerializable(typeof(JsonElement?))]
@@ -91,3 +93,21 @@ public sealed record SpawnListenerArgs();
 
 public sealed record CloseListenerArgs(
     [property: JsonPropertyName("port")] int Port);
+
+// close_slot's structured response. `closed=true` is the happy path;
+// `closed=false` covers both "no such slot" and "refused" cases, with `error`
+// and `message` populated when there's a specific reason the agent should
+// know about (e.g. the slot was adopted from a user-started Rhino).
+public sealed record CloseSlotResult(
+    [property: JsonPropertyName("closed")] bool Closed,
+    [property: JsonPropertyName("error")] string? Error = null,
+    [property: JsonPropertyName("message")] string? Message = null);
+
+// Drop-file shape written by the plugin into <temp>/rhino-mcp-listeners/.
+// `v` is a schema version — bump only if the file shape changes in a
+// non-additive way. Unknown future fields are ignored on read.
+public sealed record Announcement(
+    [property: JsonPropertyName("v")] int V,
+    [property: JsonPropertyName("pid")] int Pid,
+    [property: JsonPropertyName("port")] int Port,
+    [property: JsonPropertyName("version")] string? Version);

--- a/rhino/router/Tools/SpawnSlotTool.cs
+++ b/rhino/router/Tools/SpawnSlotTool.cs
@@ -32,18 +32,35 @@ public class SpawnSlotTool(RhinoManager manager, RhinoCrashReportFinder crashFin
     }
 
     [McpServerTool(Name = "close_slot")]
-    [Description("Close a Rhino slot gracefully. Saves nothing.")]
-    public Task<bool> CloseAsync(
-        [Description("Slot ID returned by spawn_slot")]
+    [Description("Close a Rhino slot gracefully. Saves nothing. Returns { closed: bool, error?: string, message?: string }. `error=\"cannot_close_adopted\"` means the slot was a user-started Rhino — the router will not kill it; ask the user to close the Rhino window.")]
+    public async Task<string> CloseAsync(
+        [Description("Slot ID returned by spawn_slot, or an animal-name slot adopted from a user-started Rhino")]
         string slot,
-        CancellationToken ct = default) => manager.CloseAsync(slot, ct);
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var ok = await manager.CloseAsync(slot, ct).ConfigureAwait(false);
+            return JsonSerializer.Serialize(new CloseSlotResult(ok), RouterJsonContext.Default.CloseSlotResult);
+        }
+        catch (AdoptedSlotCloseException ex)
+        {
+            var payload = new CloseSlotResult(
+                Closed: false,
+                Error: "cannot_close_adopted",
+                Message: ex.Message + " Ask the user to close the Rhino window themselves.");
+            return JsonSerializer.Serialize(payload, RouterJsonContext.Default.CloseSlotResult);
+        }
+    }
 
     [McpServerTool(Name = "list_slots")]
-    [Description("List all currently-running Rhino slots managed by this router. Slots whose Rhino has crashed are pruned before returning.")]
+    [Description("List all currently-running Rhino slots managed by this router. Slots whose Rhino has crashed are pruned before returning. User-started Rhinos that have advertised themselves since the last call are adopted into the list.")]
     public IReadOnlyCollection<ChildRhino> List()
     {
-        // Probe each slot before reporting; a crashed Rhino otherwise looks alive
-        // until something tries to call into it.
+        // Adopt anything the plugin has announced since the last call, then probe
+        // each slot before reporting; a crashed Rhino otherwise looks alive until
+        // something tries to call into it.
+        manager.ScanAnnouncements();
         manager.ReapAllDead();
         return manager.List();
     }


### PR DESCRIPTION
If a user starts Rhino and runs RhinoMCP, claude cannot see that and we're stuck. This change handles that scenario