### PR TITLE
Documentation Improvement

### DIFF
--- a/cc-plugin/commands/launch-rhinos.md
+++ b/cc-plugin/commands/launch-rhinos.md
@@ -67,7 +67,3 @@ Briefly tell the user:
 - That all Rhinos are now closed (or which ones couldn't be killed).
 
 The agents already reported their own results in Step 2 — no need to recap each.
-
-## Why this is simpler than the old model
-
-The router speaks **stdio** MCP to Claude Code, so the connection is alive from session start with no `/mcp` reconnect needed. Children live and die under router control on internal ports Claude never sees. One slot in `.mcp.json` (`rhino`), one MCP namespace (`mcp__plugin_rhino-mcp_rhino__*`), `slot` arg routes to the right child Rhino.

--- a/docs/content/docs/getting-started/cc-plugin.md
+++ b/docs/content/docs/getting-started/cc-plugin.md
@@ -79,7 +79,7 @@ Each agent is tuned for a different kind of work. You can call them explicitly (
 ## Try it out
 
 <blockquote class="page-note">
-Open Claude Desktop, start a new chat, and follow the prompts on the <a href="../../try-it-out">Try It Out</a> page.
+Open Claude Code and follow the prompts on the <a href="../../try-it-out">Try It Out</a> page.
 </blockquote>
 
 <!--


### PR DESCRIPTION
- Add references to MCPStart command 
- Remove old method
- Add `find-rhino` skill