### PR TITLE
feat(plugin): startup robustness + get_units/set_units tools

### DIFF
--- a/rhino/plugin/Plugin.cs
+++ b/rhino/plugin/Plugin.cs
@@ -4,16 +4,68 @@ namespace RhMcp;
 
 public class RhMcpPlugin : PlugIn
 {
+    private System.Threading.Timer? _poll;
 
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
-        RhinoDoc.BeginOpenDocument += Register;
+        // Case 1: doc already available when plugin loads (e.g. scripted load)
+        var doc = RhinoDoc.ActiveDoc;
+        if (doc != null)
+        {
+            StartServer(doc);
+            return base.OnLoad(ref errorMessage);
+        }
+
+        // Case 2: subscribe to all document-creation events
+        RhinoApp.Initialized += OnAppInitialized;
+        RhinoDoc.BeginOpenDocument += OnOpenDoc;
+        RhinoDoc.NewDocument += OnNewDoc;
+
+        // Case 3: poll fallback every 2 s in case events fire before subscription
+        _poll = new System.Threading.Timer(_ =>
+        {
+            var d = RhinoDoc.ActiveDoc;
+            if (d == null) return;
+            _poll?.Dispose(); _poll = null;
+            RhinoApp.Initialized -= OnAppInitialized;
+            RhinoDoc.BeginOpenDocument -= OnOpenDoc;
+            RhinoDoc.NewDocument -= OnNewDoc;
+            StartServer(d);
+        }, null, 2000, 2000);
+
         return base.OnLoad(ref errorMessage);
     }
 
-    private void Register(object? sender, DocumentOpenEventArgs e)
+    private void OnAppInitialized(object? sender, EventArgs e)
     {
-        RhinoDoc.BeginOpenDocument -= Register;
+        _poll?.Dispose(); _poll = null;
+        RhinoApp.Initialized -= OnAppInitialized;
+        RhinoDoc.BeginOpenDocument -= OnOpenDoc;
+        RhinoDoc.NewDocument -= OnNewDoc;
+        StartServer(RhinoDoc.ActiveDoc);
+    }
+
+    private void OnOpenDoc(object? sender, DocumentOpenEventArgs e)
+    {
+        _poll?.Dispose(); _poll = null;
+        RhinoApp.Initialized -= OnAppInitialized;
+        RhinoDoc.BeginOpenDocument -= OnOpenDoc;
+        RhinoDoc.NewDocument -= OnNewDoc;
+        StartServer(e.Document);
+    }
+
+    private void OnNewDoc(object? sender, DocumentEventArgs e)
+    {
+        _poll?.Dispose(); _poll = null;
+        RhinoApp.Initialized -= OnAppInitialized;
+        RhinoDoc.BeginOpenDocument -= OnOpenDoc;
+        RhinoDoc.NewDocument -= OnNewDoc;
+        StartServer(e.Document);
+    }
+
+    private static void StartServer(RhinoDoc? doc)
+    {
+        if (doc == null) return;
 
         string? portStr = Environment.GetEnvironmentVariable(MCPSpawnCommand.PortEnvVar);
         if (!string.IsNullOrEmpty(portStr)) return;
@@ -21,19 +73,19 @@ public class RhMcpPlugin : PlugIn
         try
         {
             int port = RhinoMcpHost.GetNextPort();
-            if (RhinoMcpHost.StartOrRestart(e.Document, port, true))
+            if (RhinoMcpHost.StartOrRestart(doc, port, true))
             {
                 RhinoApp.WriteLine("The Rhino MCP Platform is ready.");
                 return;
             }
         }
-        catch
+        catch (Exception)
         {
+            // Startup failure is non-fatal; user can invoke MCPStartCommand manually.
         }
-        
+
         RhinoApp.WriteLine("The Rhino MCP Server failed to start");
     }
 
     public override PlugInLoadTime LoadTime => PlugInLoadTime.AtStartup;
-
 }

--- a/rhino/plugin/Tools/GetUnitsTool.cs
+++ b/rhino/plugin/Tools/GetUnitsTool.cs
@@ -1,0 +1,17 @@
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class GetUnitsTool
+{
+    [McpServerTool(Name = "get_units", Title = "Get Units", ReadOnly = true, Destructive = false)]
+    [Description("Return the current model unit system (e.g. Meters, Feet, Millimeters), absolute tolerance, and angle tolerance.")]
+    public static string GetUnits(RhinoDoc doc)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            units = doc.ModelUnitSystem.ToString(),
+            tolerance = doc.ModelAbsoluteTolerance,
+            angleTolerance = doc.ModelAngleToleranceDegrees,
+        });
+    }
+}

--- a/rhino/plugin/Tools/SetUnitsTool.cs
+++ b/rhino/plugin/Tools/SetUnitsTool.cs
@@ -1,0 +1,55 @@
+using Rhino.Geometry;
+using Rhino.DocObjects;
+
+namespace RhMcp.Tools;
+
+[McpServerToolType]
+public static class SetUnitsTool
+{
+    private static readonly string[] ValidUnits =
+    [
+        "None", "Millimeters", "Centimeters", "Meters", "Kilometers",
+        "Inches", "Feet", "Miles",
+        "Microns", "Decimeters", "Dekameters", "Hectometers",
+        "Megameters", "Gigameters", "NauticalMiles",
+        "PrinterPoints", "PrinterPicas",
+        "AstronomicalUnits", "LightYears", "Parsecs",
+    ];
+
+    [McpServerTool(Name = "set_units", Title = "Set Units", ReadOnly = false, Destructive = false)]
+    [Description("Set the model unit system. Valid values: Millimeters, Centimeters, Meters, Kilometers, Inches, Feet, Miles, and others. Optionally scales existing geometry to preserve physical size.")]
+    public static string SetUnits(
+        RhinoDoc doc,
+        [Description("Target unit system name (case-insensitive). E.g. 'Meters', 'Feet', 'Millimeters'.")] string units,
+        [Description("If true, scale all existing geometry to preserve physical size. Default true.")] bool scaleGeometry = true)
+    {
+        if (!Enum.TryParse<UnitSystem>(units, ignoreCase: true, out var target))
+            return JsonSerializer.Serialize(new
+            {
+                success = false,
+                error = $"Unknown unit system '{units}'. Valid: {string.Join(", ", ValidUnits)}",
+            });
+
+        var previous = doc.ModelUnitSystem;
+        doc.ModelUnitSystem = target;
+
+        if (scaleGeometry && previous != target)
+        {
+            var scale = RhinoMath.UnitScale(previous, target);
+            var xform = Transform.Scale(Point3d.Origin, scale);
+            var settings = new ObjectEnumeratorSettings { ActiveObjects = true };
+            foreach (var obj in doc.Objects.GetObjectList(settings))
+                doc.Objects.Transform(obj.Id, xform, true);
+        }
+
+        doc.Views.Redraw();
+
+        return JsonSerializer.Serialize(new
+        {
+            success = true,
+            previous = previous.ToString(),
+            units = doc.ModelUnitSystem.ToString(),
+            tolerance = doc.ModelAbsoluteTolerance,
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- **Plugin.cs** — fix load-ordering race: subscribe to three events (`Initialized`, `BeginOpenDocument`, `NewDocument`) plus a 2 s poll fallback so the MCP server starts regardless of which signal arrives first during Rhino startup. Removes sole dependency on `BeginOpenDocument` which doesn't fire in all launch paths.
- **GetUnitsTool.cs** — new read-only tool `get_units`: returns current model unit system, absolute tolerance, and angle tolerance as JSON.
- **SetUnitsTool.cs** — new tool `set_units`: changes the model unit system with optional geometry scaling to preserve physical size; validates the target name against `UnitSystem` enum and returns previous/new state.

## Test plan

- [ ] Start Rhino fresh (no document open) — MCP server starts without manual intervention
- [ ] Open a document via File > Open — MCP server starts
- [ ] Call `get_units` via MCP — returns `{units, tolerance, angleTolerance}`
- [ ] Call `set_units` with `units="Meters", scaleGeometry=true` on a Feet document — geometry scales; `get_units` returns Meters afterward
- [ ] Call `set_units` with an invalid unit name — returns `success:false` with error message listing valid names

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Note: My agents worked on this PR while trying to make the application work on my device, if the contents of the pull request is poor, I apologizze. 