### PR TITLE
Fix Slots Dropping in Long Sessions

### DIFF
--- a/rhino/plugin/McpServer.cs
+++ b/rhino/plugin/McpServer.cs
@@ -14,8 +14,10 @@ namespace RhMcp;
 
 internal sealed class McpServer : IDisposable
 {
-    private WebApplication? _app;
+    // Needs to be volatile so main thread sees the write from ContinueWith, which runs on a background thread.
+    private volatile WebApplication? _app;
     private CancellationTokenSource? _cts;
+    private Task? _runTask;
 
     public bool HasStarted => _app is not null;
 
@@ -55,7 +57,19 @@ internal sealed class McpServer : IDisposable
             _app.MapMcp("/", endpointOptions);
 
             _cts = new CancellationTokenSource();
-            _ = _app.RunAsync(_cts.Token);
+            _runTask = _app.RunAsync(_cts.Token);
+
+            // Observe the host task. If we error after a clean start, or are stopped,
+            // set back to null so that `HasStarted` is false and next StartOrRestart works.
+            _ = _runTask.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    RhinoApp.WriteLine(
+                        $"[Rhino MCP] MCP server on port {port} stopped unexpectedly: {DescribeException(t.Exception!.GetBaseException())}");
+                }
+                _app = null;
+            }, TaskScheduler.Default);
 
             RhinoApp.WriteLine($"[Rhino MCP] MCP server currently running on http://localhost:{port}/");
             return true;
@@ -78,9 +92,24 @@ internal sealed class McpServer : IDisposable
 
     public void Stop()
     {
-        try { _cts?.Cancel(); } catch { }
-        try { _app?.StopAsync(); } catch { }
+        WebApplication? app = _app;
         _app = null;
+        try { _cts?.Cancel(); } catch { }
+        if (app is not null)
+        {
+            // Await graceful shutdown so we release the listening socket BEFORE
+            // any attempted rebind on the same port.
+            try { app.StopAsync(TimeSpan.FromSeconds(3)).GetAwaiter().GetResult(); } catch
+            {
+                RhinoApp.WriteLine($"[Rhino MCP] Failed to stop MCP server gracefully. Recommend restarting Rhino.");
+            }
+        }
+        try { _cts?.Dispose(); } catch
+        {
+            RhinoApp.WriteLine($"[Rhino MCP] Failed to dispose CancellationTokenSource");
+        }
+        _cts = null;
+        _runTask = null;
     }
 
     public void Dispose() => Stop();

--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Rhino.FileIO;
@@ -11,26 +12,37 @@ public static class RhinoMcpHost
 
     private static Dictionary<uint, McpServer> Servers { get; } = new();
 
+    // UI-thread-only!
+    private static Timer? _heartbeat;
+
+    // Re-advertise live listeners on this interval. Lets a spuriously-reaped slot 
+    // re-adopt on its own instead of staying gone until the user re-runs MCPStart. 
+    // Re-dropping a already-adopted listener is a no-op.
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(15);
+
     static RhinoMcpHost()
     {
         RhinoDoc.CloseDocument += CloseServer;
     }
 
+    // A doc that owned a listener is closing (File>New/Open, or a plain close). 
+    // Stop the server, otherwise the listener is orphaned.
     private static void CloseServer(object? sender, DocumentEventArgs e)
     {
-        Servers.Remove(e.DocumentSerialNumber);
+        if (!Servers.Remove(e.DocumentSerialNumber, out McpServer? server))
+            return;
+        server?.Stop();
+        StopHeartbeatIfIdle();
     }
 
-    public static bool HasStarted(RhinoDoc doc) => Servers.TryGetValue(doc.RuntimeSerialNumber, out McpServer? server) && (server?.HasStarted ?? false);
+    public static bool HasStarted(RhinoDoc doc) =>
+        Servers.TryGetValue(doc.RuntimeSerialNumber, out McpServer? server)
+            && (server?.HasStarted ?? false);
 
     private const int DefaultPort = 10500;
     public static int GetNextPort()
     {
-        int nextPort = DefaultPort;
-        if (Servers.Any())
-        {
-            nextPort = Servers.Max(s => s.Value.Port) + 1;
-        }
+        int nextPort = Servers.Any() ? Servers.Max(s => s.Value.Port) + 1 : DefaultPort;
 
         try
         {
@@ -56,26 +68,27 @@ public static class RhinoMcpHost
 
         var ok = server.Start(doc, port);
         if (ok)
+        {
             WriteAnnouncement(port);
+            EnsureHeartbeat();
+        }
         return ok;
     }
 
     public static void Stop(RhinoDoc doc)
     {
-        if (!Servers.TryGetValue(doc.RuntimeSerialNumber, out McpServer? server))
+        if (!Servers.Remove(doc.RuntimeSerialNumber, out McpServer? server))
             return;
-        Servers.Remove(doc.RuntimeSerialNumber);
         server?.Stop();
+        StopHeartbeatIfIdle();
     }
 
     public static bool RestartOnPort(RhinoDoc doc, int port)
     {
         if (port < 1 || port > 65535)
             return false;
-        // TODO : Check no other server is using the port and report to user
         Stop(doc);
-        Start(doc, port);
-        return true;
+        return Start(doc, port);
     }
 
     // Shared dispatch for both the interactive `MCPStart` command and the
@@ -107,6 +120,34 @@ public static class RhinoMcpHost
             RhinoApp.WriteLine($"[Rhino MCP] MCP server failed to start. Try a different port.");
         }
         return false;
+    }
+
+
+    private static void EnsureHeartbeat()
+    {
+        _heartbeat ??= new Timer(static _ => Heartbeat(), null, HeartbeatInterval, HeartbeatInterval);
+    }
+
+    private static void StopHeartbeatIfIdle()
+    {
+        if (Servers.Count == 0)
+        {
+            _heartbeat?.Dispose();
+            _heartbeat = null;
+        }
+    }
+
+    private static void Heartbeat()
+    {
+        // Heartbeat must be touched from UI thread
+        RhinoApp.InvokeOnUiThread(new Action(static () =>
+        {
+            foreach (McpServer server in Servers.Values)
+            {
+                if (server.HasStarted)
+                    WriteAnnouncement(server.Port);
+            }
+        }), null);
     }
 
     // Drop a one-shot announcement into <temp>/rhino-mcp-listeners/ so a router
@@ -160,12 +201,14 @@ public static class RhinoMcpHost
     // that file once Cocoa's deferred close has run.
     public static bool StopByPort(int port)
     {
-        var entry = Servers.FirstOrDefault(kv => kv.Value.Port == port);
+        KeyValuePair<uint, McpServer> entry = Servers.FirstOrDefault(kv => kv.Value.Port == port);
         if (entry.Value is null)
             return false;
+
+        Servers.Remove(entry.Key);
         var docSerial = entry.Key;
-        Servers.Remove(docSerial);
         entry.Value.Stop();
+        StopHeartbeatIfIdle();
 
         var doc = RhinoDoc.FromRuntimeSerialNumber(docSerial);
         if (doc is null)

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -27,6 +28,13 @@ public class RhinoManager(
     private const int ChildPortBase = 10500;
     private int StartupTimeoutSeconds { get; } = config.StartupTimeoutSeconds;
     private static readonly TimeSpan StaleLaunchingMaxAge = TimeSpan.FromSeconds(90);
+
+    // Liveness-probe budget and retries. A non-listening port, if process is alive
+    // is treated as a transient blip, until it misses PortMissThreshold times in a row.
+    // If process is dead, it is still reaped immediately.
+    private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
+    private const int PortMissThreshold = 3;
+    private readonly ConcurrentDictionary<string, int> _portMisses = new();
 
     private readonly int _routerPid = Environment.ProcessId;
 
@@ -399,11 +407,44 @@ public class RhinoManager(
 
     // Pid AND port must both be alive: on Mac one listener can die while the shared
     // app keeps running; on Windows a zombie can leave the socket bound.
-    public bool IsAlive(ChildRhino c)
+    public static bool IsAlive(ChildRhino c)
     {
         if (c.Status != SlotStatus.Ready) return true; // launching rows are pending, not dead
         if (!IsProcessAlive(c.Pid)) return false;
-        if (!IsPortListening(c.Port)) return false;
+        if (ProbePort(c.Port) != PortProbe.Listening) return false;
+        return true;
+    }
+
+    // Whether a slot should be deleted.  
+    private bool ShouldReap(ChildRhino c)
+    {
+        if (c.Status != SlotStatus.Ready) return false; // launching rows are pending, not dead
+
+        // Process death is conclusive and reaped immediately.
+        if (!IsProcessAlive(c.Pid))
+        {
+            _portMisses.TryRemove(c.SlotId, out _);
+            return true;
+        }
+
+        // A non-listening port on a live process is treated as transient until
+        // PortMissThreshold consecutive misses. 
+        if (ProbePort(c.Port) == PortProbe.Listening)
+        {
+            // A successful probe resets the counter.
+            _portMisses.TryRemove(c.SlotId, out _);
+            return false;
+        }
+
+        int misses = _portMisses.AddOrUpdate(c.SlotId, 1, (_, n) => n + 1);
+        if (misses < PortMissThreshold)
+        {
+            log.LogDebug("Slot '{Slot}' port {Port} not answering (miss {Miss}/{Threshold}); deferring reap",
+                c.SlotId, c.Port, misses, PortMissThreshold);
+            return false;
+        }
+
+        _portMisses.TryRemove(c.SlotId, out _);
         return true;
     }
 
@@ -411,7 +452,7 @@ public class RhinoManager(
     {
         var c = store.Get(slotId);
         if (c is null) return false;
-        if (IsAlive(c)) return false;
+        if (!ShouldReap(c)) return false;
         store.Delete(slotId);
         log.LogWarning("Reaped dead slot '{Slot}' (pid {Pid}, port {Port}, Rhino {Version})",
             c.SlotId, c.Pid, c.Port, c.Version);
@@ -423,7 +464,7 @@ public class RhinoManager(
         var reaped = new List<ChildRhino>();
         foreach (var c in store.ListReady())
         {
-            if (IsAlive(c)) continue;
+            if (!ShouldReap(c)) continue;
             store.Delete(c.SlotId);
             reaped.Add(c);
         }
@@ -528,17 +569,34 @@ public class RhinoManager(
         return WaitResult.Timeout;
     }
 
-    private static bool IsPortListening(int port)
+    private static bool IsPortListening(int port) => ProbePort(port) == PortProbe.Listening;
+
+    private enum PortProbe { Listening, Refused, Inconclusive }
+
+    // Probe a localhost port, distinguishing an actively-refused connection
+    // (definitively nothing listening) from a timeout/error (inconclusive)
+    private static PortProbe ProbePort(int port)
     {
         try
         {
             using var client = new TcpClient();
-            var task = client.ConnectAsync("127.0.0.1", port);
-            return task.Wait(200) && client.Connected;
+            using var cts = new CancellationTokenSource(ProbeTimeout);
+            client.ConnectAsync("127.0.0.1", port, cts.Token).AsTask().GetAwaiter().GetResult();
+            return client.Connected ? PortProbe.Listening : PortProbe.Inconclusive;
+        }
+        catch (OperationCanceledException)
+        {
+            return PortProbe.Inconclusive;
+        }
+        catch (SocketException se)
+        {
+            return se.SocketErrorCode == SocketError.ConnectionRefused
+                ? PortProbe.Refused
+                : PortProbe.Inconclusive;
         }
         catch
         {
-            return false;
+            return PortProbe.Inconclusive;
         }
     }
 }

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
@@ -29,12 +28,9 @@ public class RhinoManager(
     private int StartupTimeoutSeconds { get; } = config.StartupTimeoutSeconds;
     private static readonly TimeSpan StaleLaunchingMaxAge = TimeSpan.FromSeconds(90);
 
-    // Liveness-probe budget and retries. A non-listening port, if process is alive
-    // is treated as a transient blip, until it misses PortMissThreshold times in a row.
-    // If process is dead, it is still reaped immediately.
+    // Liveness-probe connect budget. Generous enough that a healthy localhost listener
+    // answers well inside it, so a slow connect is the exception (and inconclusive).
     private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(1);
-    private const int PortMissThreshold = 3;
-    private readonly ConcurrentDictionary<string, int> _portMisses = new();
 
     private readonly int _routerPid = Environment.ProcessId;
 
@@ -405,47 +401,11 @@ public class RhinoManager(
         try { File.Delete(path); } catch { /* next scan will retry */ }
     }
 
-    // Pid AND port must both be alive: on Mac one listener can die while the shared
-    // app keeps running; on Windows a zombie can leave the socket bound.
-    public static bool IsAlive(ChildRhino c)
-    {
-        if (c.Status != SlotStatus.Ready) return true; // launching rows are pending, not dead
-        if (!IsProcessAlive(c.Pid)) return false;
-        if (ProbePort(c.Port) != PortProbe.Listening) return false;
-        return true;
-    }
-
-    // Whether a slot should be deleted.  
-    private bool ShouldReap(ChildRhino c)
+    private static bool ShouldReap(ChildRhino c)
     {
         if (c.Status != SlotStatus.Ready) return false; // launching rows are pending, not dead
-
-        // Process death is conclusive and reaped immediately.
-        if (!IsProcessAlive(c.Pid))
-        {
-            _portMisses.TryRemove(c.SlotId, out _);
-            return true;
-        }
-
-        // A non-listening port on a live process is treated as transient until
-        // PortMissThreshold consecutive misses. 
-        if (ProbePort(c.Port) == PortProbe.Listening)
-        {
-            // A successful probe resets the counter.
-            _portMisses.TryRemove(c.SlotId, out _);
-            return false;
-        }
-
-        int misses = _portMisses.AddOrUpdate(c.SlotId, 1, (_, n) => n + 1);
-        if (misses < PortMissThreshold)
-        {
-            log.LogDebug("Slot '{Slot}' port {Port} not answering (miss {Miss}/{Threshold}); deferring reap",
-                c.SlotId, c.Port, misses, PortMissThreshold);
-            return false;
-        }
-
-        _portMisses.TryRemove(c.SlotId, out _);
-        return true;
+        if (!IsProcessAlive(c.Pid)) return true;
+        return ProbePort(c.Port) == PortProbe.Refused;   
     }
 
     public bool TryReapDead(string slotId)


### PR DESCRIPTION
Miscellany of potential fixes. I'm not entirely sure about the root cause (it takes between 30m and 2h to reproduce).

- Fixes the `// TODO` in `RestartOnPort`
- Closes the server when the document closes.
- Treats "dead process" (no PID, port refusal => reap immediately) as different from "slow port" (inconclusive, don't nuke the poor sap just yet) when connecting. I think this is the main fix.
- [Larger] uses a heartbeat system for ports to continually announce their alive-ness. After `Start`, a `Timer/RhinoApp.Idle` handler that re-calls `WriteAnnouncement(port)` every ~15–30 s for each entry in `Servers`. This makes any spuriously-reaped slot self-heal within one interval regardless of what went wrong, so even if things get dropped, it'll heal back up nicely within one interval.