### PR TITLE
Adds departures to closed servers

### DIFF
--- a/rhino/plugin/Plugin.cs
+++ b/rhino/plugin/Plugin.cs
@@ -8,6 +8,7 @@ public class RhMcpPlugin : PlugIn
     protected override LoadReturnCode OnLoad(ref string errorMessage)
     {
         RhinoDoc.BeginOpenDocument += Register;
+        RhinoDoc.CloseDocument += DeRegister;
         return base.OnLoad(ref errorMessage);
     }
 
@@ -32,6 +33,19 @@ public class RhMcpPlugin : PlugIn
         }
         
         RhinoApp.WriteLine("The Rhino MCP Server failed to start");
+    }
+
+    private void DeRegister(object? sender, DocumentEventArgs e)
+    {
+        RhinoDoc.BeginOpenDocument -= Register;
+
+        try
+        {
+            RhinoMcpHost.Stop(e.Document);
+        }
+        catch
+        {
+        }
     }
 
     public override PlugInLoadTime LoadTime => PlugInLoadTime.AtStartup;

--- a/rhino/plugin/RhMcpHost.cs
+++ b/rhino/plugin/RhMcpHost.cs
@@ -31,7 +31,11 @@ public static class RhinoMcpHost
     {
         if (!Servers.Remove(e.DocumentSerialNumber, out McpServer? server))
             return;
-        server?.Stop();
+        if (server is not null)
+        {
+            WriteDeparture(server.Port);
+            server.Stop();
+        }
         StopHeartbeatIfIdle();
     }
 
@@ -79,7 +83,11 @@ public static class RhinoMcpHost
     {
         if (!Servers.Remove(doc.RuntimeSerialNumber, out McpServer? server))
             return;
-        server?.Stop();
+        if (server is not null)
+        {
+            WriteDeparture(server.Port);
+            server.Stop();
+        }
         StopHeartbeatIfIdle();
     }
 
@@ -174,6 +182,33 @@ public static class RhinoMcpHost
         catch (Exception ex)
         {
             RhinoApp.WriteLine($"[Rhino MCP] Failed to write listener announcement: {ex.Message}");
+        }
+    }
+
+    // Inverse of the announcement: when a listener goes down cleanly (doc closed,
+    // MCPStart restart) drop a one-shot tombstone so a running router prunes the
+    // slot promptly and reports a user close as such, not a crash. Best-effort:
+    // if no router ever reads it, the router's own port probe reaps the slot.
+    // Filename MUST match the router's RhinoManager departure handling.
+    private static void WriteDeparture(int port)
+    {
+        try
+        {
+            string dir = ListenerDropDir();
+            Directory.CreateDirectory(dir);
+            int pid = Process.GetCurrentProcess().Id;
+            string version = RhinoApp.Version.Major.ToString();
+            string path = Path.Combine(dir, $"{pid}-{port}.gone");
+            string tmp = path + ".tmp";
+            string json = JsonSerializer.Serialize(new { v = 1, pid, port, version });
+            File.WriteAllText(tmp, json);
+            if (File.Exists(path))
+                File.Delete(path);
+            File.Move(tmp, path);
+        }
+        catch (Exception ex)
+        {
+            RhinoApp.WriteLine($"[Rhino MCP] Failed to write listener departure: {ex.Message}");
         }
     }
 

--- a/rhino/router/ProxyDispatcher.cs
+++ b/rhino/router/ProxyDispatcher.cs
@@ -104,6 +104,16 @@ public class ProxyDispatcher(
             }
             catch (HttpRequestException ex) when (IsConnectionFailure(ex))
             {
+                // A clean shutdown leaves a departure tombstone; a crash doesn't.
+                // Check that first so a user closing the doc/Rhino mid-call isn't
+                // reported as a crash.
+                if (manager.TryConsumeDeparture(child.Pid, child.Port))
+                {
+                    log.LogInformation("Rhino slot '{Slot}' (pid {Pid}) was closed during tool call '{Tool}'",
+                        child.SlotId, child.Pid, toolName);
+                    return WrapClosed(child, toolName, callerSlotArg: slotId, autoSpawnedSlot);
+                }
+
                 // Connection-level failure — Rhino likely crashed. Confirm via
                 // pid + port probe so we don't shout "crashed" on a transient blip.
                 if (manager.TryReapDead(child.SlotId))
@@ -154,6 +164,18 @@ public class ProxyDispatcher(
 
     private static string WrapError(ErrorInfo error, SlotInfo? autoSpawnedSlot) =>
         new ReturnResult(Payload: null, Error: error, AutoSpawnedSlot: autoSpawnedSlot).AsJson;
+
+    private static string WrapClosed(ChildRhino child, string toolName, string? callerSlotArg, SlotInfo? autoSpawnedSlot)
+    {
+        // Auto-spawn path can just retry; an explicit slot needs a fresh spawn_slot.
+        string nextAction = callerSlotArg is null
+            ? "Retry this call to auto-spawn another Rhino."
+            : "Call spawn_slot to start a new one.";
+        string message =
+            $"Rhino slot '{child.SlotId}' (Rhino {child.Version}) was closed (its document or the Rhino window was closed) " +
+            $"during '{toolName}'. The slot has been pruned. " + nextAction;
+        return WrapError(new ErrorInfo(Code: "rhino_closed", Message: message), autoSpawnedSlot);
+    }
 
     private string WrapCrash(ChildRhino child, string toolName, string? callerSlotArg, SlotInfo? autoSpawnedSlot)
     {

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -368,10 +368,17 @@ public class RhinoManager(
     // slot_not_found for a slot another router is still spawning.
     public bool Has(string slotId) => store.Get(slotId) is not null;
 
+    // Tombstones the plugin drops when a listener closes cleanly. Siblings to the
+    // *.json announcements in the same dir; MUST match RhMcpHost.WriteDeparture.
+    private const string DepartureGlob = "*.gone";
+
     // Adopt any user-started Rhino announced via the drop directory. Each file is a
-    // one-shot doorbell — always deleted, success or not.
+    // one-shot doorbell, always deleted, success or not. Departures are consumed
+    // first so a just-closed listener doesn't get re-adopted from a stale *.json.
     public void ScanAnnouncements()
     {
+        ConsumeDepartures();
+
         var dir = RouterPaths.ListenersDir;
         if (!Directory.Exists(dir)) return;
 
@@ -428,6 +435,70 @@ public class RhinoManager(
                 TryDelete(file);
             }
         }
+    }
+
+    // Consume graceful-close tombstones: a listener that went down cleanly (doc
+    // closed, MCPStart restart) drops a *.gone file so we prune its slot here
+    // instead of discovering it dead via a probe and crying crash. One-shot
+    // doorbells, always deleted, success or not.
+    public void ConsumeDepartures()
+    {
+        string dir = RouterPaths.ListenersDir;
+        if (!Directory.Exists(dir)) return;
+
+        string[] files;
+        try { files = Directory.GetFiles(dir, DepartureGlob); }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "Failed to enumerate listener-departure dir {Dir}", dir);
+            return;
+        }
+
+        foreach (string file in files)
+        {
+            try
+            {
+                Departure? dep;
+                try
+                {
+                    string json = File.ReadAllText(file);
+                    dep = JsonSerializer.Deserialize(json, RouterJsonContext.Default.Departure);
+                }
+                catch (Exception ex)
+                {
+                    log.LogWarning(ex, "Bad departure file {File}; deleting", file);
+                    TryDelete(file);
+                    continue;
+                }
+
+                if (dep is not null && dep.Port > 0)
+                {
+                    foreach (string slotId in store.DeleteByListener(dep.Pid, dep.Port))
+                    {
+                        log.LogInformation("Pruned slot '{Slot}' (pid {Pid}, port {Port}, Rhino {Version}) after graceful close",
+                            slotId, dep.Pid, dep.Port, dep.Version ?? "?");
+                    }
+                }
+                TryDelete(file);
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning(ex, "Unexpected failure processing departure {File}", file);
+                TryDelete(file);
+            }
+        }
+    }
+
+    // Did this listener leave a graceful-close tombstone? If so, consume it and
+    // prune the slot. Lets the dispatcher report a user close as such, rather
+    // than a crash, when a tool call lands on a just-closed slot.
+    public bool TryConsumeDeparture(int pid, int port)
+    {
+        string path = Path.Combine(RouterPaths.ListenersDir, $"{pid}-{port}.gone");
+        if (!File.Exists(path)) return false;
+        TryDelete(path);
+        store.DeleteByListener(pid, port);
+        return true;
     }
 
     private static void TryDelete(string path)

--- a/rhino/router/RouterJsonContext.cs
+++ b/rhino/router/RouterJsonContext.cs
@@ -23,6 +23,7 @@ namespace RhMcp.Router;
 [JsonSerializable(typeof(CloseListenerArgs))]
 [JsonSerializable(typeof(QuitAppArgs))]
 [JsonSerializable(typeof(Announcement))]
+[JsonSerializable(typeof(Departure))]
 [JsonSerializable(typeof(ReturnResult))]
 [JsonSerializable(typeof(ErrorInfo))]
 [JsonSerializable(typeof(SlotInfo))]
@@ -96,6 +97,15 @@ public sealed record QuitAppArgs();
 // `v` is a schema version — bump only if the file shape changes in a
 // non-additive way. Unknown future fields are ignored on read.
 public sealed record Announcement(
+    [property: JsonPropertyName("v")] int V,
+    [property: JsonPropertyName("pid")] int Pid,
+    [property: JsonPropertyName("port")] int Port,
+    [property: JsonPropertyName("version")] string? Version);
+
+// Tombstone the plugin drops when a listener closes cleanly. Lets the router
+// prune the slot and tell a user-initiated close apart from a crash. Sibling to
+// Announcement in the same drop dir, distinguished by a `.gone` extension.
+public sealed record Departure(
     [property: JsonPropertyName("v")] int V,
     [property: JsonPropertyName("pid")] int Pid,
     [property: JsonPropertyName("port")] int Port,

--- a/rhino/router/SlotStore.cs
+++ b/rhino/router/SlotStore.cs
@@ -298,6 +298,28 @@ public sealed class SlotStore : IDisposable
         }
     }
 
+    // Prune the slot(s) bound to a specific listener (pid+port). Drives the
+    // graceful-departure path: the plugin tells us a listener closed cleanly, so
+    // we drop its row rather than waiting to probe it dead. Returns removed ids.
+    public IReadOnlyList<string> DeleteByListener(int pid, int port)
+    {
+        lock (_connLock)
+        {
+            List<string> ids = [];
+            using (SqliteCommand cmd = _conn.CreateCommand())
+            {
+                cmd.CommandText = "SELECT slot_id FROM slots WHERE pid=$p AND port=$port;";
+                cmd.Parameters.AddWithValue("$p", pid);
+                cmd.Parameters.AddWithValue("$port", port);
+                using SqliteDataReader r = cmd.ExecuteReader();
+                while (r.Read()) ids.Add(r.GetString(0));
+            }
+            if (ids.Count > 0)
+                Exec("DELETE FROM slots WHERE pid=$p AND port=$port;", ("$p", pid), ("$port", port));
+            return ids;
+        }
+    }
+
     // Drop-file adoption. Atomically:
     //   1. Bail out (return null) if any slot already points at this (pid, port)
     //      — guards against duplicate announcements for a single listener.


### PR DESCRIPTION
When rhino starts the server drops an announcement file, on closing however Rhino is always currently reported as crashed. This PR adds a departure file so graceful closing is not reported as crashed.