### PR TITLE
Handle no plugin

### DIFF
--- a/rhino/router/PluginNotInstalledException.cs
+++ b/rhino/router/PluginNotInstalledException.cs
@@ -1,10 +1,5 @@
 namespace RhMcp.Router;
 
-// Thrown when a fresh Rhino launch would start a version whose Yak package (the
-// MCP plugin) isn't installed: that Rhino comes up but never binds its port, so
-// we fail fast with an actionable message instead of eating the full startup
-// timeout. Detection is Yak-only and Release-only (see RhinoLocator.IsPluginInstalled);
-// dev builds load the plugin from bin and never hit this.
 public sealed class PluginNotInstalledException(string version, IReadOnlyList<string> versionsWithPlugin)
     : Exception(BuildMessage(version, versionsWithPlugin))
 {

--- a/rhino/router/PluginNotInstalledException.cs
+++ b/rhino/router/PluginNotInstalledException.cs
@@ -1,0 +1,23 @@
+namespace RhMcp.Router;
+
+// Thrown when a fresh Rhino launch would start a version whose Yak package (the
+// MCP plugin) isn't installed: that Rhino comes up but never binds its port, so
+// we fail fast with an actionable message instead of eating the full startup
+// timeout. Detection is Yak-only and Release-only (see RhinoLocator.IsPluginInstalled);
+// dev builds load the plugin from bin and never hit this.
+public sealed class PluginNotInstalledException(string version, IReadOnlyList<string> versionsWithPlugin)
+    : Exception(BuildMessage(version, versionsWithPlugin))
+{
+    private const string SetupDocsUrl = "https://mcneel.github.io/RhinoMCP/docs/getting-started/";
+
+    public string Version { get; } = version;
+
+    private static string BuildMessage(string version, IReadOnlyList<string> versionsWithPlugin)
+    {
+        string where = versionsWithPlugin.Count > 0
+            ? $"It is installed for: {string.Join(", ", versionsWithPlugin)}. "
+            : "No installed Rhino has it. ";
+        return $"The Rhino MCP plugin is not installed for Rhino {version}. {where}" +
+               $"Install it for the Rhino you want to use, then retry. Setup guide: {SetupDocsUrl}";
+    }
+}

--- a/rhino/router/RhinoLocator.cs
+++ b/rhino/router/RhinoLocator.cs
@@ -96,4 +96,45 @@ public static class RhinoLocator
                 yield return version;
         }
     }
+
+    // Installed Rhino versions that also have the MCP plugin available. A miss on
+    // the plugin means launching that Rhino would come up but never bind its port,
+    // so callers use this to steer the default spawn toward a usable version.
+    public static IReadOnlyList<string> ListVersionsWithPlugin() =>
+        [.. ListInstalledVersions().Where(IsPluginInstalled)];
+
+    // The Yak package name the plugin ships under; must match rhino/plugin/manifest.yml `name`.
+    private const string PluginPackageName = "Rhino-MCP-Platform";
+
+    // Is the MCP plugin installed for `version`? Yak drops the package under
+    // packages/<major>.0/<PackageName>, and a Release Rhino always installs it that
+    // way, so a folder probe is authoritative. The whole Rhino 9 family (9/BETA/WIP)
+    // shares one packages/9.0 tree, matching how a 9-family build loads it.
+    public static bool IsPluginInstalled(string version)
+    {
+        string? packagesRoot = YakPackagesRoot();
+        if (packagesRoot is null)
+            return true; // unknown platform: don't block a launch on a check we can't make
+
+        string major = version.Equals("8", StringComparison.OrdinalIgnoreCase) ? "8.0" : "9.0";
+        return Directory.Exists(Path.Combine(packagesRoot, major, PluginPackageName));
+    }
+
+    // Root of Yak's per-version package tree. Windows: %APPDATA%\McNeel\Rhinoceros\
+    // packages. macOS: ~/Library/Application Support/McNeel/Rhinoceros/packages —
+    // NOT ~/.config, which is where .NET's ApplicationData resolves on macOS.
+    private static string? YakPackagesRoot()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                "McNeel", "Rhinoceros", "packages");
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                "Library", "Application Support", "McNeel", "Rhinoceros", "packages");
+
+        return null;
+    }
 }

--- a/rhino/router/RhinoLocator.cs
+++ b/rhino/router/RhinoLocator.cs
@@ -97,32 +97,26 @@ public static class RhinoLocator
         }
     }
 
-    // Installed Rhino versions that also have the MCP plugin available. A miss on
-    // the plugin means launching that Rhino would come up but never bind its port,
-    // so callers use this to steer the default spawn toward a usable version.
     public static IReadOnlyList<string> ListVersionsWithPlugin() =>
         [.. ListInstalledVersions().Where(IsPluginInstalled)];
 
-    // The Yak package name the plugin ships under; must match rhino/plugin/manifest.yml `name`.
+    // Must match rhino/plugin/manifest.yml `name`.
     private const string PluginPackageName = "Rhino-MCP-Platform";
 
-    // Is the MCP plugin installed for `version`? Yak drops the package under
-    // packages/<major>.0/<PackageName>, and a Release Rhino always installs it that
-    // way, so a folder probe is authoritative. The whole Rhino 9 family (9/BETA/WIP)
-    // shares one packages/9.0 tree, matching how a 9-family build loads it.
     public static bool IsPluginInstalled(string version)
     {
         string? packagesRoot = YakPackagesRoot();
         if (packagesRoot is null)
-            return true; // unknown platform: don't block a launch on a check we can't make
+            return true; // unknown platform: can't check, so don't block a launch
 
-        string major = version.Equals("8", StringComparison.OrdinalIgnoreCase) ? "8.0" : "9.0";
-        return Directory.Exists(Path.Combine(packagesRoot, major, PluginPackageName));
+        if (double.TryParse(version, out double versionMajor))
+        {
+            version = $"{(int)versionMajor}.0";
+        }
+
+        return Directory.Exists(Path.Combine(packagesRoot, version, PluginPackageName));
     }
 
-    // Root of Yak's per-version package tree. Windows: %APPDATA%\McNeel\Rhinoceros\
-    // packages. macOS: ~/Library/Application Support/McNeel/Rhinoceros/packages —
-    // NOT ~/.config, which is where .NET's ApplicationData resolves on macOS.
     private static string? YakPackagesRoot()
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -43,9 +43,6 @@ public class RhinoManager(
 
     public Task<ChildRhino> SpawnAsync(string? version = null, CancellationToken ct = default)
     {
-        // No explicit version is a preference, not a requirement: prefer one that
-        // actually has the plugin. An explicit version is honoured as-is and fails
-        // in the leader path if its plugin is missing.
         string resolved = version ?? ChooseDefaultVersion();
         store.ReapStaleLaunching(StaleLaunchingMaxAge);
         ReapAllDead();
@@ -103,18 +100,11 @@ public class RhinoManager(
         return (spawned, true);
     }
 
-    // For a version-less spawn, prefer a version that actually has the plugin so we
-    // don't launch a Rhino that can never bind. If none does, fall back to the
-    // configured default and let the leader path surface a plugin_not_installed error.
-    // Compiled out of Debug, where the plugin loads from bin and can't be seen on disk.
     private string ChooseDefaultVersion()
     {
 #if DEBUG
         return config.DefaultVersion;
 #else
-        // Launchable = installed exe AND plugin. IsPluginInstalled alone probes only
-        // the package folder, which can outlive the Rhino it belonged to, so the
-        // default would resolve to a version that then dies at ResolveRhinoExe.
         IReadOnlyList<string> usable = RhinoLocator.ListVersionsWithPlugin();
         return usable.Contains(config.DefaultVersion)
             ? config.DefaultVersion
@@ -162,11 +152,6 @@ public class RhinoManager(
             string rhinoExe = RhinoLocator.ResolveRhinoExe(version);
 
 #if !DEBUG
-            // A Rhino without the plugin launches fine but never binds its port, so
-            // catch it here rather than eating the full startup timeout. Only the
-            // leader path starts a fresh process; followers reuse a Rhino that has
-            // the plugin by definition. Dev builds load the plugin from bin, so the
-            // Yak-folder probe would false-negative and this is compiled out.
             if (!RhinoLocator.IsPluginInstalled(version))
                 throw new PluginNotInstalledException(version, RhinoLocator.ListVersionsWithPlugin());
 #endif

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -43,7 +43,10 @@ public class RhinoManager(
 
     public Task<ChildRhino> SpawnAsync(string? version = null, CancellationToken ct = default)
     {
-        string resolved = version ?? config.DefaultVersion;
+        // No explicit version is a preference, not a requirement: prefer one that
+        // actually has the plugin. An explicit version is honoured as-is and fails
+        // in the leader path if its plugin is missing.
+        string resolved = version ?? ChooseDefaultVersion();
         store.ReapStaleLaunching(StaleLaunchingMaxAge);
         ReapAllDead();
         (SlotReservation reservation, string slotId) = store.ReserveNewNamed(resolved, _routerPid);
@@ -96,12 +99,12 @@ public class RhinoManager(
             .FirstOrDefault(c => c.Status == SlotStatus.Ready && !c.Adopted);
         if (mine is not null) return (mine, false);
 
-        ChildRhino spawned = await SpawnAsync(ChooseDefaultVersion(), ct).ConfigureAwait(false);
+        ChildRhino spawned = await SpawnAsync(null, ct).ConfigureAwait(false);
         return (spawned, true);
     }
 
-    // For a no-preference auto-spawn, prefer a version that actually has the plugin
-    // so we don't launch a Rhino that can never bind. If none does, fall back to the
+    // For a version-less spawn, prefer a version that actually has the plugin so we
+    // don't launch a Rhino that can never bind. If none does, fall back to the
     // configured default and let the leader path surface a plugin_not_installed error.
     // Compiled out of Debug, where the plugin loads from bin and can't be seen on disk.
     private string ChooseDefaultVersion()
@@ -109,9 +112,13 @@ public class RhinoManager(
 #if DEBUG
         return config.DefaultVersion;
 #else
-        return RhinoLocator.IsPluginInstalled(config.DefaultVersion)
+        // Launchable = installed exe AND plugin. IsPluginInstalled alone probes only
+        // the package folder, which can outlive the Rhino it belonged to, so the
+        // default would resolve to a version that then dies at ResolveRhinoExe.
+        IReadOnlyList<string> usable = RhinoLocator.ListVersionsWithPlugin();
+        return usable.Contains(config.DefaultVersion)
             ? config.DefaultVersion
-            : RhinoLocator.ListVersionsWithPlugin().FirstOrDefault() ?? config.DefaultVersion;
+            : usable.FirstOrDefault() ?? config.DefaultVersion;
 #endif
     }
 

--- a/rhino/router/RhinoManager.cs
+++ b/rhino/router/RhinoManager.cs
@@ -96,8 +96,23 @@ public class RhinoManager(
             .FirstOrDefault(c => c.Status == SlotStatus.Ready && !c.Adopted);
         if (mine is not null) return (mine, false);
 
-        ChildRhino spawned = await SpawnAsync(config.DefaultVersion, ct).ConfigureAwait(false);
+        ChildRhino spawned = await SpawnAsync(ChooseDefaultVersion(), ct).ConfigureAwait(false);
         return (spawned, true);
+    }
+
+    // For a no-preference auto-spawn, prefer a version that actually has the plugin
+    // so we don't launch a Rhino that can never bind. If none does, fall back to the
+    // configured default and let the leader path surface a plugin_not_installed error.
+    // Compiled out of Debug, where the plugin loads from bin and can't be seen on disk.
+    private string ChooseDefaultVersion()
+    {
+#if DEBUG
+        return config.DefaultVersion;
+#else
+        return RhinoLocator.IsPluginInstalled(config.DefaultVersion)
+            ? config.DefaultVersion
+            : RhinoLocator.ListVersionsWithPlugin().FirstOrDefault() ?? config.DefaultVersion;
+#endif
     }
 
     private async Task<ChildRhino> DispatchReservationAsync(
@@ -138,6 +153,16 @@ public class RhinoManager(
         try
         {
             string rhinoExe = RhinoLocator.ResolveRhinoExe(version);
+
+#if !DEBUG
+            // A Rhino without the plugin launches fine but never binds its port, so
+            // catch it here rather than eating the full startup timeout. Only the
+            // leader path starts a fresh process; followers reuse a Rhino that has
+            // the plugin by definition. Dev builds load the plugin from bin, so the
+            // Yak-folder probe would false-negative and this is compiled out.
+            if (!RhinoLocator.IsPluginInstalled(version))
+                throw new PluginNotInstalledException(version, RhinoLocator.ListVersionsWithPlugin());
+#endif
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {

--- a/rhino/router/SpawnDiagnostics.cs
+++ b/rhino/router/SpawnDiagnostics.cs
@@ -21,6 +21,13 @@ public static class SpawnDiagnostics
                 diagnosis = new("rhino_not_installed", fnf.Message);
                 return true;
 
+            // Rhino is installed but its MCP plugin isn't, so the launch would time
+            // out waiting for a port that never binds. The message names which
+            // versions do have it and links the setup guide.
+            case PluginNotInstalledException pnie:
+                diagnosis = new("plugin_not_installed", pnie.Message);
+                return true;
+
             case TimeoutException te:
                 diagnosis = new(
                     "startup_timeout",

--- a/rhino/router/SpawnDiagnostics.cs
+++ b/rhino/router/SpawnDiagnostics.cs
@@ -21,9 +21,6 @@ public static class SpawnDiagnostics
                 diagnosis = new("rhino_not_installed", fnf.Message);
                 return true;
 
-            // Rhino is installed but its MCP plugin isn't, so the launch would time
-            // out waiting for a port that never binds. The message names which
-            // versions do have it and links the setup guide.
             case PluginNotInstalledException pnie:
                 diagnosis = new("plugin_not_installed", pnie.Message);
                 return true;

--- a/tests/Router.Tests/RhinoLocatorTests.cs
+++ b/tests/Router.Tests/RhinoLocatorTests.cs
@@ -18,9 +18,6 @@ public class RhinoLocatorTests
         Assert.That(RhinoLocator.KnownVersionTokens, Is.EquivalentTo(new[] { "8", "9", "WIP" }));
     }
 
-    // A version can only be "launchable with the plugin" if Rhino itself is there,
-    // so the plugin-filtered list is always a subset of the installed list. Pins the
-    // invariant without depending on what's actually installed on the test machine.
     [Test]
     public void Versions_with_plugin_are_a_subset_of_installed_versions()
     {

--- a/tests/Router.Tests/RhinoLocatorTests.cs
+++ b/tests/Router.Tests/RhinoLocatorTests.cs
@@ -18,6 +18,16 @@ public class RhinoLocatorTests
         Assert.That(RhinoLocator.KnownVersionTokens, Is.EquivalentTo(new[] { "8", "9", "WIP" }));
     }
 
+    // A version can only be "launchable with the plugin" if Rhino itself is there,
+    // so the plugin-filtered list is always a subset of the installed list. Pins the
+    // invariant without depending on what's actually installed on the test machine.
+    [Test]
+    public void Versions_with_plugin_are_a_subset_of_installed_versions()
+    {
+        Assert.That(RhinoLocator.ListVersionsWithPlugin(),
+            Is.SubsetOf(RhinoLocator.ListInstalledVersions()));
+    }
+
     // "9" and "WIP" are deliberate aliases for the current WIP install; the
     // documented "8" token is distinct. This pins the aliasing so a future
     // edit can't silently make "9" mean a non-WIP install on one platform only.

--- a/tests/Router.Tests/SpawnDiagnosticsTests.cs
+++ b/tests/Router.Tests/SpawnDiagnosticsTests.cs
@@ -27,6 +27,19 @@ public class SpawnDiagnosticsTests
     }
 
     [Test]
+    public void PluginNotInstalled_classifies_with_versions_and_setup_link()
+    {
+        bool ok = SpawnDiagnostics.TryClassify(
+            new PluginNotInstalledException("8", ["9"]), Finder, out SpawnDiagnostics.SpawnDiagnosis d);
+
+        Assert.That(ok, Is.True);
+        Assert.That(d.Code, Is.EqualTo("plugin_not_installed"));
+        Assert.That(d.BaseMessage, Does.Contain("Rhino 8"));
+        Assert.That(d.BaseMessage, Does.Contain("installed for: 9"));
+        Assert.That(d.BaseMessage, Does.Contain("getting-started"));
+    }
+
+    [Test]
     public void Timeout_classifies_as_startup_timeout_with_shared_advice()
     {
         bool ok = SpawnDiagnostics.TryClassify(


### PR DESCRIPTION
Added in code that can handle no plugin being installed.

If a user asks for Rhino to open and only installed the plugin for WIP, WIP should open.