### PR TITLE
AI Agent launcher fails

### DIFF
--- a/rhino/plugin/Agents/AgentHost.cs
+++ b/rhino/plugin/Agents/AgentHost.cs
@@ -109,6 +109,12 @@ internal static class AgentHost
         DisposeDoc(doc.RuntimeSerialNumber);
     }
 
+    public static void Drop(RhinoDoc doc, string name)
+    {
+        if (Agents.Remove((doc.RuntimeSerialNumber, name), out IAgentRunner? agent))
+            SafeDispose(agent);
+    }
+
     public static void Shutdown()
     {
         foreach (IAgentRunner agent in Agents.Values.ToArray())

--- a/rhino/plugin/Agents/AgentRegistry.cs
+++ b/rhino/plugin/Agents/AgentRegistry.cs
@@ -57,30 +57,36 @@ internal static class AgentRegistry
 
     // Where a normally-installed CLI lands so it is found with zero config: every entry on PATH,
     // then the standard per-user/system install dirs, the npm global bin, and Claude Code's own
-    // local dir. On Windows the CLIs install as claude.cmd / claude.exe / gemini.cmd, so each
-    // dir+command is expanded by the executable extensions (the bare name never exists). De-duped,
-    // first-found-anywhere; probing and TryResolveCommand both just File.Exists each candidate, so
+    // local dir. On Windows the CLIs install as claude.exe (native installer) or claude.cmd /
+    // gemini.cmd (npm), so each dir+command is expanded by the executable extensions. De-duped,
+    // first-found-anywhere; probing and CliProcess.TryResolve both just File.Exists each candidate, so
     // adding to this list is the only seam needed to widen detection.
     public static IReadOnlyList<string> DefaultSearchPaths(string command)
     {
         List<string> candidates = new();
         foreach (string dir in CandidateDirs())
-            foreach (string ext in ExecutableExtensions())
+            foreach (string ext in ExecutableExtensions(command))
                 candidates.Add(Path.Combine(dir, command + ext));
         return candidates.Distinct().ToArray();
     }
 
-    // On non-Windows a CLI is the bare name (one variant, no extension). On Windows the launcher is
-    // a PATHEXT-resolved wrapper, so we probe each known extension; "" is included so a fully
-    // qualified command already carrying its extension still resolves.
-    private static IEnumerable<string> ExecutableExtensions()
+    // On non-Windows a CLI is the bare name (one variant, no extension). On Windows a bare command is
+    // resolved only through its PATHEXT variants (.EXE/.CMD/...), NEVER the extensionless name: probing
+    // the bare name resolves npm's POSIX shell shim (e.g. %APPDATA%\npm\claude), which CreateProcess
+    // rejects as "not a valid application for this OS platform". "" is offered only when the command
+    // already carries an executable extension (a full path like C:\tools\claude.exe) so it still resolves.
+    private static IEnumerable<string> ExecutableExtensions(string command)
     {
         if (!OperatingSystem.IsWindows())
             return [string.Empty];
 
-        string pathext = Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
-        string[] fromEnv = pathext.Split(';', StringSplitOptions.RemoveEmptyEntries);
-        return new[] { string.Empty }.Concat(fromEnv).Distinct(StringComparer.OrdinalIgnoreCase);
+        string[] pathext = (Environment.GetEnvironmentVariable("PATHEXT") ?? ".COM;.EXE;.BAT;.CMD")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        bool carriesExt = pathext.Any(ext => command.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+        return carriesExt ? [string.Empty] : pathext;
     }
 
     private static IEnumerable<string> CandidateDirs()
@@ -93,6 +99,7 @@ internal static class AgentRegistry
         {
             string appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
             string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            yield return Path.Combine(home, ".local", "bin");
             yield return Path.Combine(appData, "npm");
             yield return Path.Combine(localAppData, "Microsoft", "WindowsApps");
         }

--- a/rhino/plugin/Agents/CliProcess.cs
+++ b/rhino/plugin/Agents/CliProcess.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace RhMcp;
+
+// Resolves a CLI's launch binary from its search paths and points a ProcessStartInfo at it, shared by
+// every agent that spawns a line/ACP CLI so they resolve and launch identically. Two Windows realities
+// drive it: a real .exe must beat a .cmd/.bat shim (CreateProcess can't exec a batch file, and cmd.exe
+// re-parsing can mangle a newline-bearing arg like Claude's system prompt), yet the shim path is not
+// optional because some CLIs ship only a .cmd on Windows (Gemini is node-only).
+internal static class CliProcess
+{
+    // Two passes so a real .exe wins over an npm .cmd shim even when the shim's directory comes first
+    // on PATH; within each pass, search-path (PATH-first) order is preserved.
+    public static bool TryResolve(IReadOnlyList<string> searchPaths, out string path)
+    {
+        foreach (string candidate in searchPaths)
+            if (!IsBatchShim(candidate) && File.Exists(candidate))
+            {
+                path = candidate;
+                return true;
+            }
+        foreach (string candidate in searchPaths)
+            if (File.Exists(candidate))
+            {
+                path = candidate;
+                return true;
+            }
+        path = string.Empty;
+        return false;
+    }
+
+    // Call BEFORE the caller appends any CLI args: a .cmd/.bat on Windows becomes `cmd.exe /c <shim>`,
+    // so the `/c <shim>` prefix must lead the ArgumentList that the CLI's own args then follow.
+    public static void ConfigureFileName(ProcessStartInfo psi, string path)
+    {
+        if (OperatingSystem.IsWindows() && IsBatchShim(path))
+        {
+            psi.FileName = ComSpec();
+            psi.ArgumentList.Add("/c");
+            psi.ArgumentList.Add(path);
+        }
+        else
+        {
+            psi.FileName = path;
+        }
+    }
+
+    private static bool IsBatchShim(string path)
+    {
+        string ext = Path.GetExtension(path);
+        return ext.Equals(".cmd", StringComparison.OrdinalIgnoreCase)
+            || ext.Equals(".bat", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string ComSpec() =>
+        Environment.GetEnvironmentVariable("COMSPEC")
+        ?? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.System), "cmd.exe");
+}

--- a/rhino/plugin/Agents/GeminiConnection.cs
+++ b/rhino/plugin/Agents/GeminiConnection.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Acp;
@@ -12,12 +11,11 @@ internal static class GeminiConnection
 {
     public static IAcpAgent Connect(AgentDefinition def, IAcpClient client, string cwd)
     {
-        if (!TryResolveCommand(def.SearchPaths, out string path))
+        if (!CliProcess.TryResolve(def.SearchPaths, out string path))
             throw new FileNotFoundException("Gemini CLI not found. Install it (npm i -g @google/gemini-cli).");
 
         ProcessStartInfo psi = new()
         {
-            FileName = path,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -25,6 +23,7 @@ internal static class GeminiConnection
             CreateNoWindow = true,
             WorkingDirectory = cwd,
         };
+        CliProcess.ConfigureFileName(psi, path);
         psi.ArgumentList.Add("--experimental-acp");
         foreach (string arg in def.ExtraArgs)
             psi.ArgumentList.Add(arg);
@@ -62,19 +61,5 @@ internal static class GeminiConnection
             proc.Dispose();
             throw;
         }
-    }
-
-    // First match wins: SearchPaths leads with PATH, the authoritative source. Identical semantics
-    // to StreamJsonAgent.TryResolveCommand so both agents resolve the same binary off the same list.
-    private static bool TryResolveCommand(IReadOnlyList<string> searchPaths, out string path)
-    {
-        foreach (string candidate in searchPaths)
-            if (File.Exists(candidate))
-            {
-                path = candidate;
-                return true;
-            }
-        path = string.Empty;
-        return false;
     }
 }

--- a/rhino/plugin/Agents/StreamJsonAgent.cs
+++ b/rhino/plugin/Agents/StreamJsonAgent.cs
@@ -170,12 +170,11 @@ internal sealed class StreamJsonAgent : IAcpAgent, IDisposable
 
     private Task StartAsync()
     {
-        if (!TryResolveCommand(out string path))
+        if (!CliProcess.TryResolve(Definition.SearchPaths, out string path))
             throw new FileNotFoundException(Parser.NotFoundMessage);
 
         ProcessStartInfo psi = new()
         {
-            FileName = path,
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -183,6 +182,7 @@ internal sealed class StreamJsonAgent : IAcpAgent, IDisposable
             CreateNoWindow = true,
             WorkingDirectory = Cwd,
         };
+        CliProcess.ConfigureFileName(psi, path);
         Parser.ConfigureArguments(psi, McpUrl, AgentSessionIdText, ResolveMcpServers(), HasEverStarted);
 
         Process proc = new() { StartInfo = psi };
@@ -207,20 +207,6 @@ internal sealed class StreamJsonAgent : IAcpAgent, IDisposable
         }
         _ = Task.Run(() => ReadLoopAsync(proc.StandardOutput, proc));
         return Task.CompletedTask;
-    }
-
-    // The CLI binary search paths are an AgentDefinition concern, but the resolver lives here because
-    // it is process spawning, not parsing.
-    private bool TryResolveCommand(out string path)
-    {
-        foreach (string candidate in Definition.SearchPaths)
-            if (File.Exists(candidate))
-            {
-                path = candidate; // first match wins: SearchPaths leads with PATH, the authoritative source
-                return true;
-            }
-        path = string.Empty;
-        return false;
     }
 
     // The runner resolves the MCP server set from AISettings (the parser stays settings-free). Each

--- a/tests/StreamJson.Tests/AgentRegistryResolutionTests.cs
+++ b/tests/StreamJson.Tests/AgentRegistryResolutionTests.cs
@@ -149,4 +149,34 @@ public sealed class AgentRegistryResolutionTests
         Assert.That(paths.Distinct().Count(), Is.EqualTo(paths.Count));
         Assert.That(paths, Has.Some.Matches<string>(static p => Path.GetFileName(p).StartsWith("claude")));
     }
+
+    [Test]
+    public void Default_search_paths_never_probe_the_bare_extensionless_name_on_windows()
+    {
+        IReadOnlyList<string> paths = AgentRegistry.DefaultSearchPaths("claude");
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.That(
+                paths,
+                Has.None.Matches<string>(static p => Path.GetFileName(p) == "claude"),
+                "the extensionless POSIX npm shim (%APPDATA%\\npm\\claude) must never be a candidate");
+            Assert.That(paths, Has.Some.Matches<string>(static p =>
+                Path.GetFileName(p).Equals("claude.exe", StringComparison.OrdinalIgnoreCase)));
+            Assert.That(paths, Has.Some.Matches<string>(static p =>
+                Path.GetFileName(p).Equals("claude.cmd", StringComparison.OrdinalIgnoreCase)));
+        }
+        else
+        {
+            Assert.That(paths, Has.All.Matches<string>(static p => Path.GetFileName(p) == "claude"));
+        }
+    }
+
+    [Test]
+    public void Default_search_paths_probe_a_fully_qualified_command_as_is()
+    {
+        string qualified = OperatingSystem.IsWindows() ? @"C:\tools\claude.exe" : "/opt/tools/claude";
+        IReadOnlyList<string> paths = AgentRegistry.DefaultSearchPaths(qualified);
+        Assert.That(paths, Has.Some.EqualTo(qualified));
+    }
 }

--- a/tests/StreamJson.Tests/CliProcessTests.cs
+++ b/tests/StreamJson.Tests/CliProcessTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using RhMcp;
+
+namespace RhMcp.StreamJson.Tests;
+
+// CliProcess resolves the launch binary from a search-path list (real File.Exists probes over temp
+// files) and configures a ProcessStartInfo. The .cmd/.bat -> cmd.exe wrapping is Windows-only, so
+// those assertions branch on the host OS: meaningful on the Windows CI leg, a no-op elsewhere.
+[TestFixture]
+public sealed class CliProcessTests
+{
+    private string Dir { get; set; } = string.Empty;
+
+    [SetUp]
+    public void SetUp()
+    {
+        Dir = Path.Combine(Path.GetTempPath(), "rhmcp-cliproc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Dir);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(Dir))
+            Directory.Delete(Dir, recursive: true);
+    }
+
+    private string Touch(string name)
+    {
+        string path = Path.Combine(Dir, name);
+        File.WriteAllText(path, string.Empty);
+        return path;
+    }
+
+    private string Absent(string name) => Path.Combine(Dir, name);
+
+    [Test]
+    public void TryResolve_prefers_a_real_executable_over_a_cmd_shim()
+    {
+        string cmdShimListedFirst = Touch("claude.cmd");
+        string exe = Touch("claude.exe");
+
+        Assert.That(CliProcess.TryResolve([cmdShimListedFirst, exe], out string path), Is.True);
+        Assert.That(path, Is.EqualTo(exe));
+    }
+
+    [Test]
+    public void TryResolve_falls_back_to_a_cmd_shim_when_no_real_executable_exists()
+    {
+        string cmd = Touch("gemini.cmd");
+
+        Assert.That(CliProcess.TryResolve([Absent("gemini.exe"), cmd], out string path), Is.True);
+        Assert.That(path, Is.EqualTo(cmd));
+    }
+
+    [Test]
+    public void TryResolve_keeps_search_order_among_real_executables()
+    {
+        string first = Touch("claude.exe");
+        string second = Touch("claude.com");
+
+        Assert.That(CliProcess.TryResolve([first, second], out string path), Is.True);
+        Assert.That(path, Is.EqualTo(first));
+    }
+
+    [Test]
+    public void TryResolve_is_false_when_nothing_exists()
+    {
+        Assert.That(CliProcess.TryResolve([Absent("claude.exe"), Absent("claude.cmd")], out string path), Is.False);
+        Assert.That(path, Is.Empty);
+    }
+
+    [Test]
+    public void ConfigureFileName_points_directly_at_a_real_executable()
+    {
+        string exe = Touch("claude.exe");
+        ProcessStartInfo psi = new();
+
+        CliProcess.ConfigureFileName(psi, exe);
+
+        Assert.That(psi.FileName, Is.EqualTo(exe));
+        Assert.That(psi.ArgumentList, Is.Empty);
+    }
+
+    [Test]
+    public void ConfigureFileName_wraps_a_batch_shim_in_cmd_on_windows_only()
+    {
+        string cmd = Touch("claude.cmd");
+        ProcessStartInfo psi = new();
+
+        CliProcess.ConfigureFileName(psi, cmd);
+
+        if (OperatingSystem.IsWindows())
+        {
+            Assert.That(Path.GetFileName(psi.FileName), Is.EqualTo("cmd.exe").IgnoreCase);
+            Assert.That(psi.ArgumentList, Is.EqualTo(new[] { "/c", cmd }));
+        }
+        else
+        {
+            Assert.That(psi.FileName, Is.EqualTo(cmd));
+            Assert.That(psi.ArgumentList, Is.Empty);
+        }
+    }
+}

--- a/tests/StreamJson.Tests/StreamJson.Tests.csproj
+++ b/tests/StreamJson.Tests/StreamJson.Tests.csproj
@@ -38,6 +38,7 @@
     <Compile Include="../../rhino/plugin/Agents/Attachment.cs" LinkBase="PluginSources" />
     <Compile Include="../../rhino/plugin/Agents/UserMessage.cs" LinkBase="PluginSources" />
     <Compile Include="../../rhino/plugin/Agents/AcpMessageMapper.cs" LinkBase="PluginSources" />
+    <Compile Include="../../rhino/plugin/Agents/CliProcess.cs" LinkBase="PluginSources" />
     <Compile Include="../../rhino/plugin/Agents/IStreamJsonParser.cs" LinkBase="PluginSources" />
     <Compile Include="../../rhino/plugin/Agents/ParsedLine.cs" LinkBase="PluginSources" />
     <Compile Include="../../rhino/plugin/Agents/TokenUsage.cs" LinkBase="PluginSources" />


### PR DESCRIPTION
Fixes https://mcneel.myjetbrains.com/youtrack/issue/RH-96767/AI-Agents-Windows-launcher-resolves-extensionless-npm-claude-shim-fails-with-not-a-valid-application-for-this-OS-platform