### PR TITLE
Fix the MCPConnect router path when Rhino runs under Rosetta

### DIFF
--- a/rhino/plugin/RouterMcpConfig.cs
+++ b/rhino/plugin/RouterMcpConfig.cs
@@ -39,7 +39,24 @@ internal static class RouterMcpConfig
             string pluginDir = Path.GetDirectoryName(typeof(RhMcpPlugin).Assembly.Location) ?? string.Empty;
             string routerRoot = Path.GetFullPath(Path.Combine(pluginDir, "..", "router"));
             string exe = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "rhino-mcp-router.exe" : "rhino-mcp-router";
-            return Path.Combine(routerRoot, Rid, exe);
+            string preferred = Path.Combine(routerRoot, Rid, exe);
+            if (File.Exists(preferred))
+                return preferred;
+
+            // The package ships routers for a subset of RIDs. The agent launches the router,
+            // not Rhino, so any shipped binary the host can run (natively or emulated) beats
+            // handing out a path that does not exist.
+            if (Directory.Exists(routerRoot))
+            {
+                foreach (string dir in Directory.EnumerateDirectories(routerRoot))
+                {
+                    string candidate = Path.Combine(dir, exe);
+                    if (File.Exists(candidate))
+                        return candidate;
+                }
+            }
+
+            return preferred;
         }
     }
 
@@ -55,7 +72,10 @@ internal static class RouterMcpConfig
     {
         get
         {
-            string arch = RuntimeInformation.ProcessArchitecture switch
+            // OSArchitecture, not ProcessArchitecture: the agent spawns the router on the
+            // host OS, and a Rosetta-translated Rhino would otherwise report x64 on an
+            // arm64 Mac and point at a router the package never ships.
+            string arch = RuntimeInformation.OSArchitecture switch
             {
                 Architecture.Arm64 => "arm64",
                 _ => "x64",


### PR DESCRIPTION
Fixes #103.

MCPConnect built the router path from `RuntimeInformation.ProcessArchitecture`, which reports x64 inside a Rosetta-translated Rhino on Apple Silicon. The dialog then emitted `router/osx-x64/rhino-mcp-router`, a path the Mac package never ships, and the agent failed to connect with no hint why.

Two changes in `RouterMcpConfig`:

- `Rid` now uses `RuntimeInformation.OSArchitecture`, which reports the machine architecture even in a translated process. This matches what the integration test harness (`RhinoRouterPaths.CurrentRid`) already does.
- `RouterPath` now verifies the preferred path exists and otherwise falls back to whichever shipped router RID is actually on disk. The router is spawned by the agent, not by Rhino, and only talks to the session over HTTP, so any binary the host can run (natively or emulated) works. This also helps Windows on ARM, where only `win-x64` ships but runs emulated, and it degrades the missing-build case (#99) from a silently wrong path to a real one.

Verified with `dotnet build rhino/plugin/RhMcp.csproj -c Release` (0 errors), and reproduced the original bug on an M1 Max running Rhino 8.34 under Rosetta: the shipped 0.1.5 dialog emits `osx-x64`, while the same machine with Rosetta off emits `osx-arm64`.