### PR TITLE
Pin the ASP.NET Core runtime pack version

### DIFF
--- a/rhino/plugin/RhinoAI.csproj
+++ b/rhino/plugin/RhinoAI.csproj
@@ -62,8 +62,15 @@
     <EmbeddedResource Include="../../art/paperclip.svg" LogicalName="RhinoAI.paperclip.svg" />
   </ItemGroup>
 
+  <!-- Pinned, not floating. A floating 8.0.* makes every restore query a package
+       source for the newest patch, so it can never be satisfied from the global
+       packages folder alone. That is what breaks the macOS build: the osx-arm64
+       runtime pack is not already cached there and no mapped source serves it,
+       so RhinoMacBuild.sln fails restore with NU1100. 8.0.30 is the newest 8.0.x
+       and is what 8.0.* was already resolving to, so this pins today's behaviour
+       rather than changing it. Bump by hand to move to a newer 8.0 patch. -->
   <PropertyGroup>
-    <AspNetCoreRuntimeVersion>8.0.*</AspNetCoreRuntimeVersion>
+    <AspNetCoreRuntimeVersion>8.0.30</AspNetCoreRuntimeVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The macOS build fails restore on RhinoMacBuild.sln:

  RhinoAI.csproj : error NU1100: Unable to resolve
  'Microsoft.AspNetCore.App.Runtime.osx-arm64 (>= 8.0.0)' for 'net8.0'.
  PackageSourceMapping is enabled, the following source(s) were not
  considered: cecil_local, ironpython2_local, NuGet.org (v3), openvdb_local.

AspNetCoreRuntimeVersion was the floating 8.0.*, and a floating version makes NuGet query a package source on every restore to find the newest matching patch, so it can never be satisfied from the global packages folder alone. On the Windows agents the win-x64 pack is served fine; on the Mac agent the osx-arm64 pack is neither cached nor available from a source the mapping allows, so restore has nothing to resolve against.

Pin to 8.0.30. That is the newest 8.0.x for both RIDs and it is what 8.0.* was already resolving to, so the bundled framework is byte for byte what Windows builds ship today - this pins current behaviour rather than changing it.

Verified by restoring rhino/plugin/RhinoAI.csproj with -p:PluginOS=osx and -p:PluginOS=win; both resolve, and project.assets.json records Microsoft.AspNetCore.App.Runtime.osx-arm64/8.0.30.