### PR TITLE
Automatic crash processing: Don't take Rhino down when the MCP server can't load

### DIFF
--- a/rhino/plugin/McpServer.ai.cs
+++ b/rhino/plugin/McpServer.ai.cs
@@ -16,7 +16,18 @@ namespace Rhino.AI;
 
 internal sealed class McpServer : IDisposable
 {
-    private WebApplication? App { get; set; }
+    // The running WebApplication, held as object so that no member of this class is
+    // typed by Microsoft.AspNetCore.
+    //
+    // Rhino's host loads Microsoft.NETCore.App and Microsoft.WindowsDesktop.App only,
+    // so on an install where ASP.NET Core is neither bundled nor resolvable, every
+    // method whose body or signature names one of its types fails to JIT. That failure
+    // is raised in the CALLER, which is why a FileLoadException for Microsoft.AspNetCore
+    // came out of `HasStarted` - a property Start's own try/catch never gets to guard.
+    // Keeping those types inside RunApp/StopApp below, both [MethodImpl(NoInlining)] and
+    // both called from inside a try, confines the failure to a place that can catch it:
+    // the server reports that it did not start instead of taking Rhino down.
+    private object? App { get; set; }
     private CancellationTokenSource Cts { get; } = new CancellationTokenSource();
 
     public bool HasStarted => App is not null;
@@ -30,24 +41,7 @@ internal sealed class McpServer : IDisposable
         Port = port;
         try
         {
-            WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
-            {
-                // Prevent unnecesssary file watchers
-                Args = ["--hostBuilder:reloadConfigOnChange=false"],
-                ContentRootPath = Path.GetDirectoryName(typeof(McpServer).Assembly.Location),
-            });
-            builder.Logging.ClearProviders();
-            builder.Logging.AddProvider(new RhinoLoggerProvider());
-            builder.Logging.SetMinimumLevel(LogLevel.Warning);
-            builder.Services.Configure<KestrelServerOptions>(o => o.ListenLocalhost(port));
-
-            builder.Services.AddSingleton(doc);
-
-            App = builder.Build();
-            App.MapMcp("/");
-            App.MapMcp("/agent", filtered: true);
-
-            _ = App.RunAsync(Cts.Token);
+            App = RunApp(doc, port, Cts.Token);
 
             RhinoApp.WriteLine($"[RhinoAI] MCP server currently running on http://localhost:{port}/ (in-Rhino agents use /agent)");
             return true;
@@ -59,6 +53,34 @@ internal sealed class McpServer : IDisposable
             return false;
         }
     }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static object RunApp(RhinoDoc doc, int port, CancellationToken token)
+    {
+        WebApplicationBuilder builder = WebApplication.CreateSlimBuilder(new WebApplicationOptions
+        {
+            // Prevent unnecesssary file watchers
+            Args = ["--hostBuilder:reloadConfigOnChange=false"],
+            ContentRootPath = Path.GetDirectoryName(typeof(McpServer).Assembly.Location),
+        });
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new RhinoLoggerProvider());
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+        builder.Services.Configure<KestrelServerOptions>(o => o.ListenLocalhost(port));
+
+        builder.Services.AddSingleton(doc);
+
+        WebApplication app = builder.Build();
+        app.MapMcp("/");
+        app.MapMcp("/agent", filtered: true);
+
+        _ = app.RunAsync(token);
+
+        return app;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void StopApp(object app) => ((WebApplication)app).StopAsync();
 
     private static string DescribeException(Exception ex)
     {
@@ -74,7 +96,10 @@ internal sealed class McpServer : IDisposable
         { Cts?.Cancel(); }
         catch { }
         try
-        { App?.StopAsync(); }
+        {
+            if (App is object app)
+                StopApp(app);
+        }
         catch { }
         App = null;
     }


### PR DESCRIPTION
Fixes [RH-98543](https://mcneel.myjetbrains.com/youtrack/issue/RH-98543) — Stop-Ship, reported three times from the same fault group (`02f1056d34110f3013e506fd690317ece7f03a31`).

Typing a prompt into the AI panel kills Rhino outright on a build where ASP.NET Core is not available. No crash dialog, no message — the application is simply gone.

## What's wrong

Rhino's .NET 8 host loads `Microsoft.NETCore.App` and `Microsoft.WindowsDesktop.App` only (`src4/bin/<Config>/netcore/dotnetstart.8.runtimeconfig.json`), and `BundleAspNetCoreFramework` in `RhinoAI.csproj` deliberately skips in-box builds, so `Microsoft.AspNetCore` may not be resolvable at run time.

When it isn't, the JIT cannot compile any method whose body or signature names one of its types — and it raises that failure **in the caller**. That is why the reported `FileLoadException` for `Microsoft.AspNetCore, Version=8.0.0.0` came out of `McpServer.HasStarted`, a one-line property reached from `RhinoAIHost.TryGetPortFor`, rather than out of `Start()`, whose `try`/`catch` was written for exactly this and never got a chance to run.

## What this changes

- `App` is held as `object`, so no member of `McpServer` is typed by ASP.NET Core and `HasStarted` compiles to a null test that cannot fail.
- Every use of those types moves into `RunApp` / `StopApp`, both `[MethodImpl(MethodImplOptions.NoInlining)]` and both called from inside a `try`, so a JIT-time load failure surfaces at a call site that catches it.

## What this does not change

The MCP server still will not start where ASP.NET Core is missing — it now writes `[RhinoAI] Failed to start: …` to the command line instead. That message is the diagnostic the packaging question needs; deciding where Rhino ships ASP.NET Core is a separate call and is yours to make.

## Testing

Builds clean (`dotnet build rhino/plugin/RhinoAI.csproj`, 0 warnings). I have no Mac, so the crash itself is not reproduced here — the argument above is from the stack and the runtimeconfig. On a machine that reproduces it, the panel should stay alive and print the failure line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)